### PR TITLE
feat(bottomNavigation): add icons to NavigationTabs and create logout

### DIFF
--- a/navigators/bottomNavigation.js
+++ b/navigators/bottomNavigation.js
@@ -1,19 +1,38 @@
+/* eslint-disable react/display-name */
 import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+// import { Icon } from 'react-native-elements';
+import Icon from 'react-native-vector-icons/Ionicons';
 import IngredientsStack from './ingredientsStack';
 import RecipesStack from './recipesStack';
 import Menus from '../screens/MenusScreen';
 import Profile from '../screens/ProfileScreen';
+import colors from '../styles/appColors';
 
 const Tab = createBottomTabNavigator();
 
 function HomeTabs() {
   return (
     <Tab.Navigator>
-      <Tab.Screen name="Ingredients" component={IngredientsStack} />
-      <Tab.Screen name="Recipes" component={RecipesStack} />
-      <Tab.Screen name="Menus" component={Menus} />
-      <Tab.Screen name="Profile" component={Profile} />
+      <Tab.Screen name="Ingredientes" component={IngredientsStack} options={{ tabBarIcon: () => (
+        <Icon name='nutrition-outline'
+          size={30}
+          color={colors.blue}/>) }} />
+      <Tab.Screen name="Recetas" component={RecipesStack} options={{ tabBarIcon: () => (
+        <Icon name='book-outline'
+          size={30}
+          color={colors.blue}/>) }} />
+
+      <Tab.Screen name="Menús" component={Menus} options={{ tabBarIcon: () => (
+        <Icon name='menu'
+          size={30}
+          color={colors.blue}/>) }} />
+
+      <Tab.Screen name="Perfil" component={Profile} options={{ tabBarIcon: () => (
+        <Icon name='person-outline'
+          size={30}
+          color={colors.blue}/>) }} />
+
     </Tab.Navigator>
   );
 }

--- a/navigators/bottomNavigation.js
+++ b/navigators/bottomNavigation.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/display-name */
 import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-// import { Icon } from 'react-native-elements';
 import Icon from 'react-native-vector-icons/Ionicons';
 import IngredientsStack from './ingredientsStack';
 import RecipesStack from './recipesStack';

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -1,11 +1,21 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { useStoreActions } from 'easy-peasy';
 import styles from '../styles/authStyles';
 
 function Profile() {
+  const logout = useStoreActions((actions) => actions.setLogOut);
+
   return (
     <View style={styles.container}>
       <Text>Profile</Text>
+      <View style={styles.logContainer}>
+        <TouchableOpacity
+          style={styles.button}
+          onPress={() => logout()}>
+          <Text style={styles.buttonText}>Cerrar Sesión</Text>
+        </TouchableOpacity>
+      </View>
     </View>
   );
 }

--- a/screens/recipes/RecipesScreen.js
+++ b/screens/recipes/RecipesScreen.js
@@ -15,7 +15,6 @@ function Recipes(props) {
   const [errorMessage, setErrorMessage] = useState('');
   const deletedRecipe = useStoreState((state) => state.recipes.delete);
 
-
   useEffect(() => {
     getRecipes()
       .then((res) => {

--- a/screens/recipes/SingleRecipeScreen.js
+++ b/screens/recipes/SingleRecipeScreen.js
@@ -24,7 +24,7 @@ function Recipe(props) {
       ),
       headerTitle: recipe.attributes.name,
     });
-  }, [navigation, showMenu]);
+  }, [navigation, showMenu, recipe.attributes.name]);
 
   return (
     <ScrollView style={styles.mainContainer}>

--- a/store/store.js
+++ b/store/store.js
@@ -46,6 +46,11 @@ const storeActions = {
   setDeletedRecipe: action((state, payload) => {
     state.recipes.delete = payload;
   }),
+  setLogOut: action((state) => {
+    state.currentUser = null;
+    apiUtils.api.defaults.headers = { 'Accept': 'application/json',
+      'Content-Type': 'application/json' };
+  }),
 };
 
 const storeThunks = {


### PR DESCRIPTION
Contexto: estaba pendiente agregar iconos a los tabs inferiores de la navegación y, por otra parte, no era posible hacer logout de la app.
Lo que se hizo: 
- se agregaron los iconos a la navegación 
- se cambió texto de navegación a español.
- se creó un botón de logout provisorio en perfil que lleva a la pantalla de login y resetea los headers 

QA:
al lograr iniciar sesión la pantalla se debería ver así:
![WhatsApp Image 2021-05-18 at 18 15 22](https://user-images.githubusercontent.com/42247208/118730226-406a7d00-b805-11eb-8aa8-51e7f96c2697.jpeg)

Si se va al perfil la pantalla se debería ver así:
![WhatsApp Image 2021-05-18 at 18 15 23](https://user-images.githubusercontent.com/42247208/118730259-49f3e500-b805-11eb-848c-3fb6a32bd9f0.jpeg)

Al pulsar el botón debe mandar a vista de login y se puede volver a iniciar sesión con otro usuario.
