### PR TITLE
Ingredients styles

### DIFF
--- a/navigators/bottomNavigation.js
+++ b/navigators/bottomNavigation.js
@@ -13,36 +13,36 @@ const Tab = createBottomTabNavigator();
 
 function HomeTabs() {
   return (
-    <Tab.Navigator tabBarOptions={{ activeBackgroundColor: colors.figmaYellow500,
-      inactiveBackgroundColor: colors.figmaBlack,
-      activeTintColor: colors.figmaWhite,
-      inactiveTintColor: colors.figmaWhite,
+    <Tab.Navigator tabBarOptions={{ activeBackgroundColor: colors.kitchengramYellow500,
+      inactiveBackgroundColor: colors.kitchengramBlack,
+      activeTintColor: colors.kitchengramWhite,
+      inactiveTintColor: colors.kitchengramWhite,
       labelPosition: 'below-icon' }}>
 
       <Tab.Screen name="Ingredientes" component={IngredientsStack} options={{ tabBarIcon: () => (
         <Icon name='nutrition-outline'
           size={30}
-          color={colors.figmaWhite}/>) }} />
+          color={colors.kitchengramWhite}/>) }} />
 
       <Tab.Screen name="Recetas" component={RecipesStack} options={{ tabBarIcon: () => (
         <Icon name='book-outline'
           size={30}
-          color={colors.figmaWhite}/>) }} />
+          color={colors.kitchengramWhite}/>) }} />
 
       <Tab.Screen name="Menus" component={MenusStack} options={{ tabBarIcon: () => (
         <Icon name='menu'
           size={30}
-          color={colors.figmaWhite}/>) }} />
+          color={colors.kitchengramWhite}/>) }} />
 
       <Tab.Screen name="Proveedores" component={ProvidersStack} options={{ tabBarIcon: () => (
         <Icon name='fast-food-outline'
           size={30}
-          color={colors.figmaWhite}/>) }} />
+          color={colors.kitchengramWhite}/>) }} />
 
       <Tab.Screen name="Perfil" component={Profile} options={{ tabBarIcon: () => (
         <Icon name='person-outline'
           size={30}
-          color={colors.figmaWhite}/>) }} />
+          color={colors.kitchengramWhite}/>) }} />
 
     </Tab.Navigator>
   );

--- a/navigators/bottomNavigation.js
+++ b/navigators/bottomNavigation.js
@@ -13,31 +13,36 @@ const Tab = createBottomTabNavigator();
 
 function HomeTabs() {
   return (
-    <Tab.Navigator>
+    <Tab.Navigator tabBarOptions={{ activeBackgroundColor: colors.figmaYellow500,
+      inactiveBackgroundColor: colors.figmaBlack,
+      activeTintColor: colors.figmaWhite,
+      inactiveTintColor: colors.figmaWhite,
+      labelPosition: 'below-icon' }}>
+
       <Tab.Screen name="Ingredientes" component={IngredientsStack} options={{ tabBarIcon: () => (
         <Icon name='nutrition-outline'
           size={30}
-          color={colors.blue}/>) }} />
+          color={colors.figmaWhite}/>) }} />
 
       <Tab.Screen name="Recetas" component={RecipesStack} options={{ tabBarIcon: () => (
         <Icon name='book-outline'
           size={30}
-          color={colors.blue}/>) }} />
+          color={colors.figmaWhite}/>) }} />
 
       <Tab.Screen name="Menus" component={MenusStack} options={{ tabBarIcon: () => (
         <Icon name='menu'
           size={30}
-          color={colors.blue}/>) }} />
+          color={colors.figmaWhite}/>) }} />
 
       <Tab.Screen name="Proveedores" component={ProvidersStack} options={{ tabBarIcon: () => (
         <Icon name='fast-food-outline'
           size={30}
-          color={colors.blue}/>) }} />
+          color={colors.figmaWhite}/>) }} />
 
       <Tab.Screen name="Perfil" component={Profile} options={{ tabBarIcon: () => (
         <Icon name='person-outline'
           size={30}
-          color={colors.blue}/>) }} />
+          color={colors.figmaWhite}/>) }} />
 
     </Tab.Navigator>
   );

--- a/navigators/ingredientsStack.js
+++ b/navigators/ingredientsStack.js
@@ -5,31 +5,59 @@ import IndexIngredient from '../screens/Ingredients/IndexIngredientScreen';
 import ShowIngredient from '../screens/Ingredients/ShowIngredientScreen';
 import FormIngredient from '../screens/Ingredients/FormIngredientScreen';
 import SearchIngredient from '../screens/Ingredients/SearchIngredientScreen';
+import colors from '../styles/appColors';
 
 const MainIngredientsStack = createStackNavigator();
 
 function IngredientsStackScreen() {
   return (
-    <MainIngredientsStack.Navigator initialRouteName="Ingredients" >
+    <MainIngredientsStack.Navigator initialRouteName="Ingredients">
       <MainIngredientsStack.Screen
         name="Ingredientes"
         component={IndexIngredient}
+        options={{ headerTintColor: colors.figmaWhite,
+          headerTitleAlign: 'left',
+          headerStyle: { backgroundColor: colors.figmaBlack,
+          } }}
       />
       <MainIngredientsStack.Screen
         name="Ingrediente"
         component={ShowIngredient}
+        options={{ headerTintColor: colors.figmaWhite,
+          headerTitleAlign: 'center',
+          headerStyle: { backgroundColor: colors.figmaBlack,
+          },
+          headerBackTitleVisible: false,
+        }}
       />
       <MainIngredientsStack.Screen
         name="Nuevo Ingrediente"
         component={FormIngredient}
+        options={{ headerTintColor: colors.figmaWhite,
+          headerTitleAlign: 'center',
+          headerTitle: 'Crear ingrediente',
+          headerStyle: { backgroundColor: colors.figmaBlack,
+          },
+          headerBackTitleVisible: false,
+        }}
       />
       <MainIngredientsStack.Screen
         name="Editar Ingrediente"
         component={FormIngredient}
+        options={{ headerTintColor: colors.figmaWhite,
+          headerTitleAlign: 'center',
+          headerStyle: { backgroundColor: colors.figmaBlack,
+          },
+          headerBackTitleVisible: false }}
       />
       <MainIngredientsStack.Screen
         name="Buscar Ingrediente"
         component={SearchIngredient}
+        options={{ headerTintColor: colors.figmaWhite,
+          headerTitleAlign: 'center',
+          headerStyle: { backgroundColor: colors.figmaBlack,
+          },
+          headerBackTitleVisible: false }}
       />
     </MainIngredientsStack.Navigator>
   );

--- a/navigators/ingredientsStack.js
+++ b/navigators/ingredientsStack.js
@@ -15,17 +15,17 @@ function IngredientsStackScreen() {
       <MainIngredientsStack.Screen
         name="Ingredientes"
         component={IndexIngredient}
-        options={{ headerTintColor: colors.figmaWhite,
+        options={{ headerTintColor: colors.kitchengramWhite,
           headerTitleAlign: 'left',
-          headerStyle: { backgroundColor: colors.figmaBlack,
+          headerStyle: { backgroundColor: colors.kitchengramBlack,
           } }}
       />
       <MainIngredientsStack.Screen
         name="Ingrediente"
         component={ShowIngredient}
-        options={{ headerTintColor: colors.figmaWhite,
+        options={{ headerTintColor: colors.kitchengramWhite,
           headerTitleAlign: 'center',
-          headerStyle: { backgroundColor: colors.figmaBlack,
+          headerStyle: { backgroundColor: colors.kitchengramBlack,
           },
           headerBackTitleVisible: false,
         }}
@@ -33,10 +33,10 @@ function IngredientsStackScreen() {
       <MainIngredientsStack.Screen
         name="Nuevo Ingrediente"
         component={FormIngredient}
-        options={{ headerTintColor: colors.figmaWhite,
+        options={{ headerTintColor: colors.kitchengramWhite,
           headerTitleAlign: 'center',
           headerTitle: 'Crear ingrediente',
-          headerStyle: { backgroundColor: colors.figmaBlack,
+          headerStyle: { backgroundColor: colors.kitchengramBlack,
           },
           headerBackTitleVisible: false,
         }}
@@ -44,18 +44,18 @@ function IngredientsStackScreen() {
       <MainIngredientsStack.Screen
         name="Editar Ingrediente"
         component={FormIngredient}
-        options={{ headerTintColor: colors.figmaWhite,
+        options={{ headerTintColor: colors.kitchengramWhite,
           headerTitleAlign: 'center',
-          headerStyle: { backgroundColor: colors.figmaBlack,
+          headerStyle: { backgroundColor: colors.kitchengramBlack,
           },
           headerBackTitleVisible: false }}
       />
       <MainIngredientsStack.Screen
         name="Buscar Ingrediente"
         component={SearchIngredient}
-        options={{ headerTintColor: colors.figmaWhite,
+        options={{ headerTintColor: colors.kitchengramWhite,
           headerTitleAlign: 'center',
-          headerStyle: { backgroundColor: colors.figmaBlack,
+          headerStyle: { backgroundColor: colors.kitchengramBlack,
           },
           headerBackTitleVisible: false }}
       />

--- a/screens/Ingredients/FormIngredientScreen.js
+++ b/screens/Ingredients/FormIngredientScreen.js
@@ -8,10 +8,12 @@ import {
   View,
 } from 'react-native';
 import RNPickerSelect from 'react-native-picker-select';
+import Icon from 'react-native-vector-icons/Ionicons';
 import { useStoreActions } from 'easy-peasy';
 
 import styles from '../../styles/Ingredients/formStyles';
 import pickers from '../../styles/customPickerStyles';
+import colors from '../../styles/appColors';
 
 function FormIngredient({ navigation, route }) {
   const {
@@ -116,7 +118,7 @@ function FormIngredient({ navigation, route }) {
           })}
           style={styles.scrapperButton}>
           <Text style={styles.scrapperButtonText}>
-            Buscar Ingrediente
+            Buscar ingrediente
           </Text>
         </TouchableOpacity>
       )}
@@ -140,6 +142,7 @@ function FormIngredient({ navigation, route }) {
           style={styles.input}
           placeholder="Precio de ingrediente..."
           keyboardType="number-pad"
+          returnKeyType='done'
           value={price.toString()}
           onChangeText={(text) => setPrice(text)}
           editable={!isFromSearch}
@@ -153,6 +156,7 @@ function FormIngredient({ navigation, route }) {
           style={styles.input}
           placeholder="Cantidad de ingrediente..."
           keyboardType="number-pad"
+          returnKeyType='done'
           value={quantity.toString()}
           onChangeText={(text) => setQuantity(text)}
           editable={!isFromSearch}
@@ -180,7 +184,13 @@ function FormIngredient({ navigation, route }) {
                 { label: 'Ml', value: 'Ml', key: '3' },
               ]}
             />
+
           </View>
+          <Icon name='chevron-down'
+            size={30}
+            color={colors.figmaGray600}
+            style={styles.arrowIcon}
+          />
         </View>
       )}
       <View style={styles.buttonsContainer}>
@@ -191,7 +201,7 @@ function FormIngredient({ navigation, route }) {
             () => navigation.navigate('Ingrediente')}
         >
           <Text style={[styles.buttonText, styles.cancelText]}>
-            Cancelar
+            {(isNew) ? 'Volver' : 'Cancelar'}
           </Text>
         </TouchableOpacity>
         <TouchableOpacity
@@ -199,7 +209,7 @@ function FormIngredient({ navigation, route }) {
           onPress={(isNew) ? handleSubmitNew : handleSubmitEdit}
         >
           <Text style={[styles.buttonText, styles.confirmText]}>
-            {isNew ? 'Agregar ingrediente' : 'Editar ingrediente'}
+            {isNew ? 'Crear ingrediente' : 'Editar ingrediente'}
           </Text>
         </TouchableOpacity>
       </View>

--- a/screens/Ingredients/FormIngredientScreen.js
+++ b/screens/Ingredients/FormIngredientScreen.js
@@ -188,7 +188,7 @@ function FormIngredient({ navigation, route }) {
           </View>
           <Icon name='chevron-down'
             size={30}
-            color={colors.figmaGray600}
+            color={colors.kitchengramGray600}
             style={styles.arrowIcon}
           />
         </View>

--- a/screens/Ingredients/IndexIngredientScreen.js
+++ b/screens/Ingredients/IndexIngredientScreen.js
@@ -9,8 +9,10 @@ import {
   ScrollView,
 } from 'react-native';
 import { useStoreActions } from 'easy-peasy';
-
+import Icon from 'react-native-vector-icons/Ionicons';
 import styles from '../../styles/Ingredients/indexStyles';
+import colors from '../../styles/appColors';
+import formatMoney from '../../utils/formatMoney';
 
 function IndexIngredients({ navigation }) {
   const getIngredients = useStoreActions((actions) => actions.getIngredients);
@@ -26,6 +28,23 @@ function IndexIngredients({ navigation }) {
       .catch(() => {
       });
   }, [getIngredients]);
+
+  React.useLayoutEffect(() => {
+    navigation.setOptions({
+    // eslint-disable-next-line react/display-name
+      headerRight: () => (
+        <Icon name='add'
+          size={30}
+          color={colors.figmaWhite}
+          style={{ paddingRight: 10 }}
+          onPress={() => navigation.navigate('Nuevo Ingrediente', {
+            isNew: true,
+            ingredients,
+            setIngredients,
+          })}/>
+      ),
+    });
+  }, [navigation, ingredients]);
 
   return (
     <View style={styles.container}>
@@ -52,22 +71,17 @@ function IndexIngredients({ navigation }) {
             </View>
             <View style={styles.right}>
               <Text style={styles.price}>
-                {`$${ingredient.attributes.price}`}
+                {formatMoney(ingredient.attributes.price, '$')}
+              </Text>
+              <Text style={styles.measure}>
+                {`${formatMoney(
+                  ingredient.attributes.price / ingredient.attributes.quantity, '$')
+                } / ${ingredient.attributes.measure}`}
               </Text>
             </View>
           </TouchableOpacity>
         ))}
       </ScrollView>
-      <TouchableOpacity
-        style={styles.addButton}
-        onPress={() => navigation.navigate('Nuevo Ingrediente', {
-          isNew: true,
-          ingredients,
-          setIngredients,
-        })}
-      >
-        <Text style={styles.plus}>+</Text>
-      </TouchableOpacity>
     </View>
   );
 }

--- a/screens/Ingredients/IndexIngredientScreen.js
+++ b/screens/Ingredients/IndexIngredientScreen.js
@@ -35,7 +35,7 @@ function IndexIngredients({ navigation }) {
       headerRight: () => (
         <Icon name='add'
           size={30}
-          color={colors.figmaWhite}
+          color={colors.kitchengramWhite}
           style={{ paddingRight: 10 }}
           onPress={() => navigation.navigate('Nuevo Ingrediente', {
             isNew: true,

--- a/screens/Ingredients/SearchIngredientScreen.js
+++ b/screens/Ingredients/SearchIngredientScreen.js
@@ -9,8 +9,10 @@ import {
 } from 'react-native';
 import { useStoreActions } from 'easy-peasy';
 import RNPickerSelect from 'react-native-picker-select';
+import Icon from 'react-native-vector-icons/Ionicons';
 import styles from '../../styles/Ingredients/searchStyles';
 import pickers from '../../styles/customPickerStyles';
+import colors from '../../styles/appColors';
 
 function SearchIngredient({ navigation, route }) {
   const {
@@ -52,7 +54,7 @@ function SearchIngredient({ navigation, route }) {
           onPress={() => handleSubmit()}
           style={styles.scrapperButton}>
           <Text style={styles.scrapperButtonText}>
-          Buscar Ingrediente
+          Buscar ingrediente
           </Text>
         </TouchableOpacity>
       </View>
@@ -76,6 +78,11 @@ function SearchIngredient({ navigation, route }) {
                   label: element.provider.name,
                   value: i,
                 }))}
+              />
+              <Icon name='chevron-down'
+                size={25}
+                color={colors.figmaWhite}
+                style={styles.arrowIcon}
               />
             </View>
             {searchResponse[actualProvider].products.map((product, i) => (
@@ -108,7 +115,7 @@ function SearchIngredient({ navigation, route }) {
                   <Text style={styles.price}>
                     {`$ ${product.price}`}
                   </Text>
-                  <Text style={styles.package}>
+                  <Text style={styles.measure}>
                     {product.package}
                   </Text>
                 </View>

--- a/screens/Ingredients/SearchIngredientScreen.js
+++ b/screens/Ingredients/SearchIngredientScreen.js
@@ -66,7 +66,7 @@ function SearchIngredient({ navigation, route }) {
                 style={pickers.providerPicker}
                 key={'0'}
                 placeholder={{
-                  label: 'Escoge tu proveedor...',
+                  label: 'Selecciona proveedor...',
                   value: 0,
                 }}
                 value={actualProvider.name}
@@ -81,7 +81,7 @@ function SearchIngredient({ navigation, route }) {
               />
               <Icon name='chevron-down'
                 size={25}
-                color={colors.kitchengramWhite}
+                color={colors.kitchengramGreen500}
                 style={styles.arrowIcon}
               />
             </View>

--- a/screens/Ingredients/SearchIngredientScreen.js
+++ b/screens/Ingredients/SearchIngredientScreen.js
@@ -81,7 +81,7 @@ function SearchIngredient({ navigation, route }) {
               />
               <Icon name='chevron-down'
                 size={25}
-                color={colors.figmaWhite}
+                color={colors.kitchengramWhite}
                 style={styles.arrowIcon}
               />
             </View>

--- a/screens/Ingredients/ShowIngredientScreen.js
+++ b/screens/Ingredients/ShowIngredientScreen.js
@@ -3,6 +3,7 @@ import {
   View,
   TouchableOpacity,
   Text,
+  Alert,
 } from 'react-native';
 import { useStoreActions } from 'easy-peasy';
 import formatMoney from '../../utils/formatMoney';
@@ -89,7 +90,14 @@ function ShowIngredient({ navigation, route }) {
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.delete}
-          onPress={handleSubmitDelete}
+          // onPress={handleSubmitDelete}
+          onPress={() => Alert.alert('¿Estás seguro?', 'Esta acción es irreversible',
+            [{ text: 'Cancelar', onPress: () => {}, style: 'default' },
+              { text: 'Borrar', onPress: () => {
+                handleSubmitDelete();
+                navigation.navigate('Ingredientes');
+              }, style: 'destructive' }],
+          )}
         >
           <Text style={styles.deleteText}>
             Borrar

--- a/screens/Ingredients/ShowIngredientScreen.js
+++ b/screens/Ingredients/ShowIngredientScreen.js
@@ -90,7 +90,6 @@ function ShowIngredient({ navigation, route }) {
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.delete}
-          // onPress={handleSubmitDelete}
           onPress={() => Alert.alert('¿Estás seguro?', 'Esta acción es irreversible',
             [{ text: 'Cancelar', onPress: () => {}, style: 'default' },
               { text: 'Borrar', onPress: () => {

--- a/screens/Ingredients/ShowIngredientScreen.js
+++ b/screens/Ingredients/ShowIngredientScreen.js
@@ -5,7 +5,7 @@ import {
   Text,
 } from 'react-native';
 import { useStoreActions } from 'easy-peasy';
-
+import formatMoney from '../../utils/formatMoney';
 import styles from '../../styles/showStyles';
 
 function ShowIngredient({ navigation, route }) {
@@ -44,7 +44,7 @@ function ShowIngredient({ navigation, route }) {
           Precio
         </Text>
         <Text style={styles.value}>
-          {ingredient.attributes.price}
+          {formatMoney(ingredient.attributes.price, '$')}
         </Text>
       </View>
       <View style={styles.attributeContainer}>
@@ -68,18 +68,12 @@ function ShowIngredient({ navigation, route }) {
           Precio por unidad
         </Text>
         <Text style={styles.value}>
-          {ingredient.attributes.price}
+          {`${formatMoney(
+            ingredient.attributes.price / ingredient.attributes.quantity, '$')
+          } / ${ingredient.attributes.measure}`}
         </Text>
       </View>
       <View style={styles.buttonsContainer}>
-        <TouchableOpacity
-          style={styles.delete}
-          onPress={handleSubmitDelete}
-        >
-          <Text style={styles.deleteText}>
-            Borrar
-          </Text>
-        </TouchableOpacity>
         <TouchableOpacity
           style={styles.edit}
           onPress={() => navigation.navigate('Editar Ingrediente', {
@@ -91,6 +85,14 @@ function ShowIngredient({ navigation, route }) {
         >
           <Text style={styles.editText}>
             Editar
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.delete}
+          onPress={handleSubmitDelete}
+        >
+          <Text style={styles.deleteText}>
+            Borrar
           </Text>
         </TouchableOpacity>
       </View>

--- a/screens/Providers/ShowProviderScreen.js
+++ b/screens/Providers/ShowProviderScreen.js
@@ -85,14 +85,6 @@ function ShowProvider({ navigation, route }) {
       </View>
       <View style={styles.buttonsContainer}>
         <TouchableOpacity
-          style={styles.delete}
-          onPress={handleSubmitDelete}
-        >
-          <Text style={styles.deleteText}>
-            Borrar
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
           style={styles.edit}
           onPress={() => {
             navigation.navigate('Editar Proveedor', {
@@ -105,6 +97,14 @@ function ShowProvider({ navigation, route }) {
         >
           <Text style={styles.editText}>
             Editar
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.delete}
+          onPress={handleSubmitDelete}
+        >
+          <Text style={styles.deleteText}>
+            Borrar
           </Text>
         </TouchableOpacity>
       </View>

--- a/screens/recipes/RecipesScreen.js
+++ b/screens/recipes/RecipesScreen.js
@@ -22,17 +22,17 @@ function Recipes(props) {
 
   useEffect(() => {
     if (loadRecipes) {
-    getRecipes()
-      .then((res) => {
-        setRecipes(res);
-      })
-      .catch((err) => {
-        setShowError(true);
-        setErrorMessage(err);
-      })
-      .finally(() => {
-        setLoadRecipes(false);
-      })
+      getRecipes()
+        .then((res) => {
+          setRecipes(res);
+        })
+        .catch((err) => {
+          setShowError(true);
+          setErrorMessage(err);
+        })
+        .finally(() => {
+          setLoadRecipes(false);
+        });
     }
   }, [loadRecipes]);
 

--- a/styles/Ingredients/formStyles.js
+++ b/styles/Ingredients/formStyles.js
@@ -3,15 +3,16 @@ import colors from '../appColors';
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: colors.figmaWhite,
     alignItems: 'center',
-    width: '100%',
     height: '100%',
+    width: '100%',
     paddingTop: 15,
+    paddingHorizontal: '5%',
   },
 
   inputContainer: {
-    width: '75%',
+    width: '100%',
     height: '10%',
     flexDirection: 'column',
     justifyContent: 'center',
@@ -23,14 +24,14 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: 'normal',
     fontStyle: 'normal',
-    color: colors.tableBorder,
+    color: colors.figmaBlack,
     marginBottom: 5,
   },
 
   input: {
     width: '100%',
-    height: '85%',
-    borderColor: colors.tableBorder,
+    height: '90%',
+    borderColor: colors.figmaGray600,
     borderWidth: 2,
     borderRadius: 5,
     fontSize: 14,
@@ -38,59 +39,76 @@ const styles = StyleSheet.create({
     paddingRight: 15,
     fontWeight: 'bold',
     fontStyle: 'normal',
-    color: '#111111',
+    color: colors.figmaBlack,
   },
 
   dropDown: {
     width: '100%',
-    height: '85%',
-    borderColor: colors.tableBorder,
+    height: '90%',
+    borderColor: colors.figmaGray600,
     borderWidth: 2,
     borderRadius: 5,
+    paddingRight: 10,
+    justifyContent: 'center',
+  },
+
+  dropDownText: {
+    width: '100%',
+    height: '100%',
     fontSize: 16,
+  },
+
+  arrowIcon: {
+    position: 'absolute',
+    top: '45%',
+    left: '87%',
   },
 
   buttonsContainer: {
     width: '100%',
-    height: '20%',
+    height: '15%',
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'space-between',
     position: 'absolute',
     bottom: 0,
     left: 0,
+    marginHorizontal: '5%',
+    paddingVertical: '5%',
   },
 
   button: {
-    height: '30%',
+    height: '100%',
     alignItems: 'center',
     justifyContent: 'center',
   },
 
   scrapperButton: {
-    backgroundColor: colors.greenButtons,
+    backgroundColor: colors.figmaGreen500,
     padding: 12,
     borderRadius: 5,
     height: '8%',
-    width: '75%',
+    width: '100%',
     alignItems: 'center',
     justifyContent: 'center',
-    marginVertical: 10 },
+    marginTop: 10 },
 
   scrapperButtonText: {
-    color: colors.white,
-    fontWeight: 'bold',
+    color: colors.figmaWhite,
+    fontSize: 16,
   },
 
   cancel: {
-    width: '30%',
+    width: '48%',
     backgroundColor: 'transparent',
-    marginRight: 10,
+    borderWidth: 1,
+    borderRadius: 5,
+    borderColor: colors.figmaGray600,
   },
 
   confirm: {
-    width: '55%',
-    backgroundColor: colors.greenButtons,
+    width: '48%',
+    backgroundColor: colors.figmaGreen500,
     borderRadius: 5,
   },
 
@@ -101,11 +119,11 @@ const styles = StyleSheet.create({
   },
 
   cancelText: {
-    color: colors.greenButtons,
+    color: colors.figmaGray600,
   },
 
   confirmText: {
-    color: colors.white,
+    color: colors.figmaWhite,
   },
 });
 

--- a/styles/Ingredients/formStyles.js
+++ b/styles/Ingredients/formStyles.js
@@ -3,7 +3,7 @@ import colors from '../appColors';
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: colors.figmaWhite,
+    backgroundColor: colors.kitchengramWhite,
     alignItems: 'center',
     height: '100%',
     width: '100%',
@@ -24,14 +24,14 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: 'normal',
     fontStyle: 'normal',
-    color: colors.figmaBlack,
+    color: colors.kitchengramBlack,
     marginBottom: 5,
   },
 
   input: {
     width: '100%',
     height: '90%',
-    borderColor: colors.figmaGray600,
+    borderColor: colors.kitchengramGray600,
     borderWidth: 2,
     borderRadius: 5,
     fontSize: 14,
@@ -39,13 +39,13 @@ const styles = StyleSheet.create({
     paddingRight: 15,
     fontWeight: 'bold',
     fontStyle: 'normal',
-    color: colors.figmaBlack,
+    color: colors.kitchengramBlack,
   },
 
   dropDown: {
     width: '100%',
     height: '90%',
-    borderColor: colors.figmaGray600,
+    borderColor: colors.kitchengramGray600,
     borderWidth: 2,
     borderRadius: 5,
     paddingRight: 10,
@@ -84,7 +84,7 @@ const styles = StyleSheet.create({
   },
 
   scrapperButton: {
-    backgroundColor: colors.figmaGreen500,
+    backgroundColor: colors.kitchengramGreen500,
     padding: 12,
     borderRadius: 5,
     height: '8%',
@@ -94,7 +94,7 @@ const styles = StyleSheet.create({
     marginTop: 10 },
 
   scrapperButtonText: {
-    color: colors.figmaWhite,
+    color: colors.kitchengramWhite,
     fontSize: 16,
   },
 
@@ -103,12 +103,12 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
     borderWidth: 1,
     borderRadius: 5,
-    borderColor: colors.figmaGray600,
+    borderColor: colors.kitchengramGray600,
   },
 
   confirm: {
     width: '48%',
-    backgroundColor: colors.figmaGreen500,
+    backgroundColor: colors.kitchengramGreen500,
     borderRadius: 5,
   },
 
@@ -119,11 +119,11 @@ const styles = StyleSheet.create({
   },
 
   cancelText: {
-    color: colors.figmaGray600,
+    color: colors.kitchengramGray600,
   },
 
   confirmText: {
-    color: colors.figmaWhite,
+    color: colors.kitchengramWhite,
   },
 });
 

--- a/styles/Ingredients/indexStyles.js
+++ b/styles/Ingredients/indexStyles.js
@@ -3,7 +3,7 @@ import colors from '../appColors';
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: colors.figmaWhite,
     flex: 1,
   },
 
@@ -13,18 +13,20 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'flex-start',
+    borderBottomColor: colors.figmaGray400,
+    borderBottomWidth: 1,
   },
 
   even: {
-    backgroundColor: '#EEEEEE',
+    backgroundColor: colors.figmaWhite,
   },
 
   odd: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: colors.figmaWhite,
   },
 
   left: {
-    width: '60%',
+    width: '65%',
     height: '100%',
     paddingLeft: '5%',
     flexDirection: 'column',
@@ -33,23 +35,23 @@ const styles = StyleSheet.create({
   },
 
   name: {
-    fontSize: 17,
-    color: '#111111',
+    fontSize: 20,
+    color: colors.figmaGray600,
 
     fontWeight: 'normal',
     fontStyle: 'normal',
   },
 
   measure: {
-    fontSize: 15,
-    color: '#767676',
+    fontSize: 12,
+    color: colors.figmaGray400,
 
     fontWeight: 'normal',
     fontStyle: 'normal',
   },
 
   right: {
-    width: '40%',
+    width: '35%',
     height: '100%',
     paddingRight: '5%',
     flexDirection: 'column',
@@ -58,15 +60,15 @@ const styles = StyleSheet.create({
   },
 
   price: {
-    fontSize: 18,
-    color: '#BC31EA',
+    fontSize: 24,
+    color: colors.figmaYellow500,
 
     fontWeight: 'normal',
     fontStyle: 'normal',
   },
 
   addButton: {
-    backgroundColor: colors.greenButtons,
+    backgroundColor: colors.figmaGreen500,
     width: 45,
     height: 45,
     borderRadius: 50,

--- a/styles/Ingredients/indexStyles.js
+++ b/styles/Ingredients/indexStyles.js
@@ -3,7 +3,7 @@ import colors from '../appColors';
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: colors.figmaWhite,
+    backgroundColor: colors.kitchengramWhite,
     flex: 1,
   },
 
@@ -13,16 +13,16 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'flex-start',
-    borderBottomColor: colors.figmaGray400,
+    borderBottomColor: colors.kitchengramGray400,
     borderBottomWidth: 1,
   },
 
   even: {
-    backgroundColor: colors.figmaWhite,
+    backgroundColor: colors.kitchengramWhite,
   },
 
   odd: {
-    backgroundColor: colors.figmaWhite,
+    backgroundColor: colors.kitchengramWhite,
   },
 
   left: {
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
 
   name: {
     fontSize: 20,
-    color: colors.figmaGray600,
+    color: colors.kitchengramGray600,
 
     fontWeight: 'normal',
     fontStyle: 'normal',
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
 
   measure: {
     fontSize: 12,
-    color: colors.figmaGray400,
+    color: colors.kitchengramGray400,
 
     fontWeight: 'normal',
     fontStyle: 'normal',
@@ -61,14 +61,14 @@ const styles = StyleSheet.create({
 
   price: {
     fontSize: 24,
-    color: colors.figmaYellow500,
+    color: colors.kitchengramYellow500,
 
     fontWeight: 'normal',
     fontStyle: 'normal',
   },
 
   addButton: {
-    backgroundColor: colors.figmaGreen500,
+    backgroundColor: colors.kitchengramGreen500,
     width: 45,
     height: 45,
     borderRadius: 50,

--- a/styles/Ingredients/searchStyles.js
+++ b/styles/Ingredients/searchStyles.js
@@ -42,13 +42,12 @@ const styles = StyleSheet.create({
     marginTop: 30,
     borderWidth: 2,
     borderColor: colors.kitchengramGreen500,
-    backgroundColor: colors.kitchengramGreen500,
     height: 45,
-    borderTopRightRadius: 7,
-    borderTopLeftRadius: 7,
-    width: '100%',
+    borderRadius: 5,
+    width: '90%',
+    marginHorizontal: '5%',
+    marginBottom: 15,
     flexDirection: 'column',
-    paddingHorizontal: 'auto',
   },
 
   arrowIcon: {

--- a/styles/Ingredients/searchStyles.js
+++ b/styles/Ingredients/searchStyles.js
@@ -3,7 +3,7 @@ import colors from '../appColors';
 
 const styles = StyleSheet.create({
   scroll: {
-    backgroundColor: colors.figmaWhite,
+    backgroundColor: colors.kitchengramWhite,
     width: '100%',
     height: '100%',
     position: 'relative',
@@ -11,14 +11,14 @@ const styles = StyleSheet.create({
 
   searchText: {
     fontSize: 14,
-    color: colors.figmaBlack,
+    color: colors.kitchengramBlack,
     width: '100%',
     marginBottom: 5,
   },
 
   container: {
     flex: 1,
-    backgroundColor: colors.figmaWhite,
+    backgroundColor: colors.kitchengramWhite,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
@@ -41,8 +41,8 @@ const styles = StyleSheet.create({
   customPickerBox: {
     marginTop: 30,
     borderWidth: 2,
-    borderColor: colors.figmaGreen500,
-    backgroundColor: colors.figmaGreen500,
+    borderColor: colors.kitchengramGreen500,
+    backgroundColor: colors.kitchengramGreen500,
     height: 45,
     borderTopRightRadius: 7,
     borderTopLeftRadius: 7,
@@ -62,19 +62,19 @@ const styles = StyleSheet.create({
     height: '45%',
     marginTop: 5,
     borderWidth: 2,
-    borderColor: colors.figmaGray600,
+    borderColor: colors.kitchengramGray600,
     borderRadius: 5,
     paddingHorizontal: 10,
 
   },
 
   scrapperButtonText: {
-    color: colors.figmaWhite,
+    color: colors.kitchengramWhite,
     fontSize: 16,
   },
 
   scrapperButton: {
-    backgroundColor: colors.figmaGreen500,
+    backgroundColor: colors.kitchengramGreen500,
     padding: 12,
     borderRadius: 5,
     width: '100%',
@@ -91,17 +91,17 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     position: 'relative',
-    borderBottomColor: colors.figmaGray400,
+    borderBottomColor: colors.kitchengramGray400,
     borderBottomWidth: 1,
     paddingLeft: '7%',
   },
 
   even: {
-    backgroundColor: colors.figmaWhite,
+    backgroundColor: colors.kitchengramWhite,
   },
 
   odd: {
-    backgroundColor: colors.figmaWhite,
+    backgroundColor: colors.kitchengramWhite,
   },
 
   left: {
@@ -123,7 +123,7 @@ const styles = StyleSheet.create({
   productName: {
     width: '72%',
     fontSize: 16,
-    color: colors.figmaGray600,
+    color: colors.kitchengramGray600,
     fontWeight: 'normal',
     fontStyle: 'normal',
     paddingLeft: 5,
@@ -141,14 +141,14 @@ const styles = StyleSheet.create({
 
   price: {
     fontSize: 20,
-    color: colors.figmaYellow500,
+    color: colors.kitchengramYellow500,
     fontWeight: 'normal',
     fontStyle: 'normal',
   },
 
   measure: {
     fontSize: 12,
-    color: colors.figmaGray400,
+    color: colors.kitchengramGray400,
     fontWeight: 'normal',
     fontStyle: 'normal',
     textAlign: 'right',

--- a/styles/Ingredients/searchStyles.js
+++ b/styles/Ingredients/searchStyles.js
@@ -11,19 +11,23 @@ const styles = StyleSheet.create({
 
   searchText: {
     fontSize: 14,
-    color: colors.tableBorder,
-    width: '75%',
+    color: colors.figmaBlack,
+    width: '100%',
+    marginBottom: 5,
   },
 
   container: {
     flex: 1,
-    backgroundColor: colors.white,
+    backgroundColor: colors.figmaWhite,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'flex-start',
     paddingTop: '5%',
     position: 'relative',
+    paddingHorizontal: '5%',
+    marginBottom: '5%',
+
   },
 
   responseContainer: {
@@ -32,31 +36,33 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'flex-start',
-    position: 'relative',
   },
 
   customPickerBox: {
-    marginTop: 20,
-    marginBottom: 10,
+    marginTop: 30,
     borderWidth: 2,
     borderColor: colors.greenButtons,
     backgroundColor: colors.greenButtons,
-    height: 40,
+    height: 45,
     borderTopRightRadius: 7,
     borderTopLeftRadius: 7,
-    borderBottomRightRadius: 7,
-    borderBottomLeftRadius: 7,
-    width: '80%',
+    width: '100%',
     flexDirection: 'column',
     paddingHorizontal: 'auto',
   },
 
+  arrowIcon: {
+    position: 'absolute',
+    top: '18%',
+    left: '90%',
+  },
+
   input: {
-    width: '75%',
-    height: 40,
+    width: '100%',
+    height: '45%',
     marginTop: 5,
     borderWidth: 2,
-    borderColor: colors.tableBorder,
+    borderColor: colors.figmaGray600,
     borderRadius: 5,
     paddingHorizontal: 10,
 
@@ -64,14 +70,14 @@ const styles = StyleSheet.create({
 
   scrapperButtonText: {
     color: colors.white,
-    fontWeight: 'bold',
+    fontSize: 16,
   },
 
   scrapperButton: {
     backgroundColor: colors.greenButtons,
     padding: 12,
     borderRadius: 5,
-    width: '76%',
+    width: '100%',
     alignItems: 'center',
     justifyContent: 'center',
     marginTop: 10,
@@ -83,12 +89,15 @@ const styles = StyleSheet.create({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'space-between',
     position: 'relative',
+    borderBottomColor: colors.figmaGray400,
+    borderBottomWidth: 1,
+    paddingLeft: '7%',
   },
 
   even: {
-    backgroundColor: '#EEEEEE',
+    backgroundColor: colors.white,
   },
 
   odd: {
@@ -112,15 +121,16 @@ const styles = StyleSheet.create({
   },
 
   productName: {
-    width: '70%',
-    fontSize: 17,
-    color: '#111111',
+    width: '72%',
+    fontSize: 16,
+    color: colors.figmaGray600,
     fontWeight: 'normal',
     fontStyle: 'normal',
+    paddingLeft: 5,
   },
 
   right: {
-    width: '20%',
+    width: '25%',
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
@@ -130,17 +140,18 @@ const styles = StyleSheet.create({
   },
 
   price: {
-    fontSize: 18,
-    color: '#BC31EA',
+    fontSize: 20,
+    color: colors.figmaYellow500,
     fontWeight: 'normal',
     fontStyle: 'normal',
   },
 
   measure: {
-    fontSize: 15,
-    color: '#767676',
+    fontSize: 12,
+    color: colors.figmaGray400,
     fontWeight: 'normal',
     fontStyle: 'normal',
+    textAlign: 'right',
   },
 });
 

--- a/styles/Ingredients/searchStyles.js
+++ b/styles/Ingredients/searchStyles.js
@@ -3,7 +3,7 @@ import colors from '../appColors';
 
 const styles = StyleSheet.create({
   scroll: {
-    backgroundColor: colors.white,
+    backgroundColor: colors.figmaWhite,
     width: '100%',
     height: '100%',
     position: 'relative',
@@ -41,8 +41,8 @@ const styles = StyleSheet.create({
   customPickerBox: {
     marginTop: 30,
     borderWidth: 2,
-    borderColor: colors.greenButtons,
-    backgroundColor: colors.greenButtons,
+    borderColor: colors.figmaGreen500,
+    backgroundColor: colors.figmaGreen500,
     height: 45,
     borderTopRightRadius: 7,
     borderTopLeftRadius: 7,
@@ -69,12 +69,12 @@ const styles = StyleSheet.create({
   },
 
   scrapperButtonText: {
-    color: colors.white,
+    color: colors.figmaWhite,
     fontSize: 16,
   },
 
   scrapperButton: {
-    backgroundColor: colors.greenButtons,
+    backgroundColor: colors.figmaGreen500,
     padding: 12,
     borderRadius: 5,
     width: '100%',
@@ -97,11 +97,11 @@ const styles = StyleSheet.create({
   },
 
   even: {
-    backgroundColor: colors.white,
+    backgroundColor: colors.figmaWhite,
   },
 
   odd: {
-    backgroundColor: colors.white,
+    backgroundColor: colors.figmaWhite,
   },
 
   left: {

--- a/styles/appColors.js
+++ b/styles/appColors.js
@@ -1,5 +1,5 @@
 const colors = {
-  // figma colors
+  // kitchengram colors
   kitchengramBlack: '#0A000A',
   kitchengramYellow500: '#DCAB24',
   kitchengramGray600: '#847974',

--- a/styles/appColors.js
+++ b/styles/appColors.js
@@ -1,12 +1,12 @@
 const colors = {
   // figma colors
-  figmaBlack: '#0A000A',
-  figmaYellow500: '#DCAB24',
-  figmaGray600: '#847974',
-  figmaGray400: '#B4ADAA',
-  figmaWhite: '#FCFBFB',
-  figmaGreen500: '#2B8E65',
-  figmaRed500: '#D62839',
+  kitchengramBlack: '#0A000A',
+  kitchengramYellow500: '#DCAB24',
+  kitchengramGray600: '#847974',
+  kitchengramGray400: '#B4ADAA',
+  kitchengramWhite: '#FCFBFB',
+  kitchengramGreen500: '#2B8E65',
+  kitchengramRed500: '#D62839',
 
   blue: '#074eec',
   white: '#fff',

--- a/styles/appColors.js
+++ b/styles/appColors.js
@@ -1,4 +1,13 @@
 const colors = {
+  // figma colors
+  figmaBlack: '#0A000A',
+  figmaYellow500: '#DCAB24',
+  figmaGray600: '#847974',
+  figmaGray400: '#B4ADAA',
+  figmaWhite: '#FCFBFB',
+  figmaGreen500: '#2B8E65',
+  figmaRed500: '#D62839',
+
   blue: '#074eec',
   white: '#fff',
   red: 'red',

--- a/styles/customPickerStyles.js
+++ b/styles/customPickerStyles.js
@@ -55,7 +55,7 @@ const pickers = {
   },
   providerPicker: {
     inputIOS: {
-      color: 'white',
+      color: colors.figmaWhite,
       textAlign: 'center',
       paddingTop: 13,
       paddingHorizontal: 10,
@@ -65,7 +65,7 @@ const pickers = {
     },
     inputAndroid: {
       textAlign: 'center',
-      color: colors.white,
+      color: colors.figmaWhite,
       paddingTop: 20,
       paddingBottom: 13,
       marginHorizontal: 10,

--- a/styles/customPickerStyles.js
+++ b/styles/customPickerStyles.js
@@ -3,40 +3,27 @@ import colors from './appColors';
 const pickers = {
   customPickerStyles: {
     inputWeb: {
-      color: '#AAAAAA',
+      color: colors.kitchengramBlack,
       paddingTop: 13,
-      paddingHorizontal: 10,
-      paddingBottom: 12,
-      borderColor: '#AAAAAA',
-      borderWidth: 2,
-      borderRadius: 5,
-      fontSize: 16,
       paddingLeft: 15,
-      paddingRight: 15,
+      paddingBottom: 12,
       fontWeight: 'bold',
-      fontStyle: 'normal',
     },
     inputIOS: {
-      color: '#111111',
+      color: colors.kitchengramBlack,
       paddingTop: 13,
       paddingLeft: 15,
       paddingBottom: 12,
       fontWeight: 'bold',
     },
     inputAndroid: {
-      color: 'yellow',
+      color: colors.kitchengramBlack,
       paddingTop: 13,
       paddingLeft: 15,
       paddingBottom: 12,
-      width: '100%',
-      height: '60%',
-      borderColor: '#AAAAAA',
-      borderWidth: 2,
-      borderRadius: 5,
-      fontSize: 16,
       fontWeight: 'bold',
     },
-    placeholderColor: '#111111',
+    placeholderColor: 'colors.kitchengramBlack',
     underline: { borderTopWidth: 0 },
     icon: {
       position: 'absolute',
@@ -55,7 +42,7 @@ const pickers = {
   },
   providerPicker: {
     inputIOS: {
-      color: colors.kitchengramWhite,
+      color: colors.kitchengramGreen500,
       textAlign: 'center',
       paddingTop: 13,
       paddingHorizontal: 10,
@@ -65,13 +52,13 @@ const pickers = {
     },
     inputAndroid: {
       textAlign: 'center',
-      color: colors.kitchengramWhite,
+      color: colors.kitchengramGreen500,
       paddingTop: 20,
       paddingBottom: 13,
       marginHorizontal: 10,
       fontSize: 16,
     },
-    placeholderColor: colors.white,
+    placeholderColor: colors.kitchengramGreen500,
   },
 };
 

--- a/styles/customPickerStyles.js
+++ b/styles/customPickerStyles.js
@@ -55,7 +55,7 @@ const pickers = {
   },
   providerPicker: {
     inputIOS: {
-      color: colors.figmaWhite,
+      color: colors.kitchengramWhite,
       textAlign: 'center',
       paddingTop: 13,
       paddingHorizontal: 10,
@@ -65,7 +65,7 @@ const pickers = {
     },
     inputAndroid: {
       textAlign: 'center',
-      color: colors.figmaWhite,
+      color: colors.kitchengramWhite,
       paddingTop: 20,
       paddingBottom: 13,
       marginHorizontal: 10,

--- a/styles/customPickerStyles.js
+++ b/styles/customPickerStyles.js
@@ -19,14 +19,14 @@ const pickers = {
     inputIOS: {
       color: '#111111',
       paddingTop: 13,
-      paddingHorizontal: 10,
+      paddingLeft: 15,
       paddingBottom: 12,
       fontWeight: 'bold',
     },
     inputAndroid: {
       color: 'yellow',
       paddingTop: 13,
-      paddingHorizontal: 10,
+      paddingLeft: 15,
       paddingBottom: 12,
       width: '100%',
       height: '60%',
@@ -57,18 +57,19 @@ const pickers = {
     inputIOS: {
       color: 'white',
       textAlign: 'center',
-      fontWeight: 'bold',
       paddingTop: 13,
       paddingHorizontal: 10,
       paddingBottom: 12,
+      fontSize: 16,
+
     },
     inputAndroid: {
       textAlign: 'center',
       color: colors.white,
-      fontWeight: 'bold',
       paddingTop: 20,
       paddingBottom: 13,
       marginHorizontal: 10,
+      fontSize: 16,
     },
     placeholderColor: colors.white,
   },

--- a/styles/showStyles.js
+++ b/styles/showStyles.js
@@ -3,40 +3,38 @@ import colors from './appColors';
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: colors.figmaWhite,
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'flex-start',
     paddingTop: 15,
     flex: 1,
+    paddingHorizontal: '5%',
   },
 
   attributeContainer: {
-    width: '80%',
-    height: '10%',
-    borderBottomColor: '#AAAAAA',
-    borderBottomWidth: 2,
+    height: '12%',
+    borderBottomColor: colors.figmaGray400,
+    borderBottomWidth: 1,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
   },
 
   name: {
-    width: '50%',
+    width: '40%',
     textAlign: 'left',
-    fontSize: 15,
-    color: '#767676',
-
+    fontSize: 14,
+    color: colors.figmaGray600,
     fontWeight: 'normal',
     fontStyle: 'normal',
   },
 
   value: {
-    width: '50%',
+    width: '60%',
     textAlign: 'right',
-    fontSize: 17,
-    color: '#111111',
-
+    fontSize: 20,
+    color: colors.figmaGray600,
     fontWeight: 'normal',
     fontStyle: 'normal',
   },
@@ -44,45 +42,45 @@ const styles = StyleSheet.create({
   buttonsContainer: {
     width: '100%',
     height: '15%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     position: 'absolute',
     bottom: 0,
     left: 0,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
+    marginHorizontal: '5%',
+    paddingVertical: '5%',
   },
 
   delete: {
-    width: '40%',
-    height: '30%',
-    backgroundColor: '#FFFFFF',
-    borderRadius: 10,
-    borderColor: colors.greenButtons,
-    borderWidth: 2,
+    width: '48%',
+    height: '100%',
+    backgroundColor: colors.figmaRed500,
+    borderRadius: 5,
     alignItems: 'center',
     justifyContent: 'center',
-    marginRight: 10,
   },
 
   deleteText: {
-    color: colors.greenButtons,
-
+    color: colors.figmaWhite,
     fontWeight: 'normal',
     fontStyle: 'normal',
     fontSize: 16,
   },
 
   edit: {
-    width: '40%',
-    height: '30%',
-    backgroundColor: colors.greenButtons,
-    borderRadius: 10,
     alignItems: 'center',
     justifyContent: 'center',
+    width: '48%',
+    height: '100%',
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderRadius: 5,
+    borderColor: colors.figmaGray600,
   },
 
   editText: {
-    color: '#FFFFFF',
+    color: colors.figmaGray600,
 
     fontWeight: 'normal',
     fontStyle: 'normal',

--- a/styles/showStyles.js
+++ b/styles/showStyles.js
@@ -3,7 +3,7 @@ import colors from './appColors';
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: colors.figmaWhite,
+    backgroundColor: colors.kitchengramWhite,
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'flex-start',
@@ -14,7 +14,7 @@ const styles = StyleSheet.create({
 
   attributeContainer: {
     height: '12%',
-    borderBottomColor: colors.figmaGray400,
+    borderBottomColor: colors.kitchengramGray400,
     borderBottomWidth: 1,
     flexDirection: 'row',
     alignItems: 'center',
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
     width: '40%',
     textAlign: 'left',
     fontSize: 14,
-    color: colors.figmaGray600,
+    color: colors.kitchengramGray600,
     fontWeight: 'normal',
     fontStyle: 'normal',
   },
@@ -34,7 +34,7 @@ const styles = StyleSheet.create({
     width: '60%',
     textAlign: 'right',
     fontSize: 20,
-    color: colors.figmaGray600,
+    color: colors.kitchengramGray600,
     fontWeight: 'normal',
     fontStyle: 'normal',
   },
@@ -55,14 +55,14 @@ const styles = StyleSheet.create({
   delete: {
     width: '48%',
     height: '100%',
-    backgroundColor: colors.figmaRed500,
+    backgroundColor: colors.kitchengramRed500,
     borderRadius: 5,
     alignItems: 'center',
     justifyContent: 'center',
   },
 
   deleteText: {
-    color: colors.figmaWhite,
+    color: colors.kitchengramWhite,
     fontWeight: 'normal',
     fontStyle: 'normal',
     fontSize: 16,
@@ -76,11 +76,11 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
     borderWidth: 1,
     borderRadius: 5,
-    borderColor: colors.figmaGray600,
+    borderColor: colors.kitchengramGray600,
   },
 
   editText: {
-    color: colors.figmaGray600,
+    color: colors.kitchengramGray600,
 
     fontWeight: 'normal',
     fontStyle: 'normal',


### PR DESCRIPTION
Que se hizo:
- se cambió la UX por la UI en las screens de ingredientes: index, show, create, edit, delete (alerta) y buscar.
- se cambió el botón de agregar ingrediente al header.
- se creó la alerta para confirmar el delete en el show
- se cambió los colores del bottom navigator de la UX al de UI
- se cambio los colores y estilos de stack navigator de ingredientes

QA:
Al entrar a la aplicación los tabs de abajo deberían estar negros con los íconos en blanco y el tab seleccionado en amarillo.
El index de ingredientes se debería ver así (imágenes en ios):
![IMG_6327](https://user-images.githubusercontent.com/42247208/121195515-aadb6f80-c83d-11eb-8e01-0b9b1b0c7d11.png)
Al apretar un ingrediente se debería ver algo así:
![WhatsApp Image 2021-06-08 at 09 48 59](https://user-images.githubusercontent.com/42247208/121196881-d6128e80-c83e-11eb-8c89-900a999b52c7.jpeg)

Si se apreta editar:
![IMG_6329](https://user-images.githubusercontent.com/42247208/121196363-6c928000-c83e-11eb-9980-1d01227f8e9e.png)

Si volvemos al index y apretamos el + del header:
![IMG_6330](https://user-images.githubusercontent.com/42247208/121195722-d8c0b400-c83d-11eb-8d87-c64232ad9ea0.png)
y si ponemos buscar y realizamos una busqueda algo así:
![IMG_6331](https://user-images.githubusercontent.com/42247208/121195809-ec6c1a80-c83d-11eb-8caa-91d4bc17a2a7.png)

Pendiente: quizás cambiar íconos de BottomNavigation, borrar colores de appColors que no se van a utilizar (esto será cuando se termine el refactor), quizás cambiar el uso de alertas para eliminar para poder editarlas más.

UPDATE: arreglado nombre de commits! Cambié el nombre de los figma colors y eliminado el comentario 