### PR TITLE
feat(menus): create menu and calculate menu price

### DIFF
--- a/api/menus.js
+++ b/api/menus.js
@@ -1,3 +1,4 @@
+import { decamelizeKeys } from 'humps';
 import config from '../config';
 import apiUtils from './api';
 
@@ -12,12 +13,12 @@ const menusApi = {
     });
   },
   createMenu: (payload) => {
-    const url = config.endpoints.recipes.new;
+    const url = config.endpoints.menus.new;
 
     return apiUtils.api({
       method: 'post',
       url,
-      data: payload,
+      data: decamelizeKeys(payload),
     });
   },
   editMenu: (payload) => {
@@ -26,7 +27,7 @@ const menusApi = {
     return apiUtils.api({
       method: 'put',
       url,
-      data: payload.body,
+      data: decamelizeKeys(payload.body),
     });
   },
 };

--- a/components/menuSelectRecipesRow.js
+++ b/components/menuSelectRecipesRow.js
@@ -1,15 +1,20 @@
 import { View, Text, TextInput } from 'react-native';
 import React, { useState } from 'react';
 import { TouchableOpacity } from 'react-native-gesture-handler';
-import { CheckBox } from 'react-native-elements';
+import { CheckBox, Icon } from 'react-native-elements';
 import styles from '../styles/Menus/form';
 import colors from '../styles/appColors';
 
-function SelectRecipeRow({ recipe }) {
-  const [quantity, setQuantity] = useState(1);
+function SelectRecipeRow({ select, recipe, remove, changePrice }) {
+  const [quantity, setQuantity] = useState(recipe.quantity);
   const [quantityText, setQuantityText] = useState(recipe.quantityText);
-  const [checked, setChecked] = useState(false);
+  const [checked, setChecked] = useState(recipe.selected);
   const [price, setPrice] = useState(recipe.price * recipe.quantity);
+
+  function changeQty() {
+    setQuantity(Number(quantityText));
+    if (!select) changePrice(false);
+  }
 
   function addRecipeQty(diff) {
     const newQuantity = quantity + diff;
@@ -18,6 +23,8 @@ function SelectRecipeRow({ recipe }) {
       setQuantityText(newQuantity.toString());
       setPrice(newQuantity * recipe.price);
       recipe.quantity = newQuantity;
+      recipe.quantityText = newQuantity.toString();
+      if (!select) changePrice(false);
     }
   }
 
@@ -30,13 +37,14 @@ function SelectRecipeRow({ recipe }) {
   return (
     <View style={styles.recipeRow}>
       <View style={styles.recipeCheckAndQtyRow}>
-        <CheckBox
-          checked={checked}
-          onPress={pressCheckBox}
-          checkedColor={colors.yellow}
-          checkedIcon='check-square'
-          uncheckedColor={colors.yellow}
-        />
+        { select ?
+          <CheckBox
+            checked={checked}
+            onPress={pressCheckBox}
+            checkedColor={colors.yellow}
+            checkedIcon='check-square'
+            uncheckedColor={colors.yellow}/> : null
+        }
         <View style={styles.nameandQtyColumn}>
           <Text style={styles.recipeNameText}>{recipe.name}</Text>
           <View style={styles.recipeMoreAndLessRow}>
@@ -49,7 +57,7 @@ function SelectRecipeRow({ recipe }) {
               style={styles.moreAndLessNumberArea}
               value={quantityText}
               onChangeText={setQuantityText}
-              onEndEditing={() => setQuantity(Number(quantityText))}
+              onEndEditing={changeQty}
             />
             <TouchableOpacity
               style={styles.recipeMoreAndLessButton}
@@ -61,6 +69,7 @@ function SelectRecipeRow({ recipe }) {
       </View>
       <View style={styles.priceAndRemoveRow}>
         <Text style={styles.recipePriceText}>${Math.round(price)}</Text>
+        {select ? null : <Icon name='close' onPress={() => remove(recipe.id)} size={18} color={colors.grayIcon}/>}
       </View>
     </View>
   );

--- a/screens/Menus/FormMenuScreen.js
+++ b/screens/Menus/FormMenuScreen.js
@@ -1,15 +1,71 @@
-import { useStoreActions } from 'easy-peasy';
+import { useStoreActions, useStoreState } from 'easy-peasy';
 import { View, Text, ScrollView, TextInput } from 'react-native';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import styles from '../../styles/Menus/form';
-import RecipeRow from '../../components/menuRecipeRow';
+import RecipeRow from '../../components/menuSelectRecipesRow';
 
-function MenuForm(props) {
-  const { navigation } = props;
+/* eslint max-statements: [2, 20] */
+function MenuForm({ navigation, menu }) {
+  const createMenu = useStoreActions((actions) => actions.createMenu);
+  const editMenu = useStoreActions((actions) => actions.editMenu);
+  const selectedRecipes = useStoreState((state) => state.menus.selectedRecipes);
+  const setSelectedRecipes = useStoreActions((actions) => actions.setMenuSelectedRecipes);
+
   const [menuName, setMenuName] = useState('');
   const [menuPortions, setMenuPortions] = useState('');
   const [menuTotalPrice, setMenuTotalPrice] = useState(0);
+  const [menuRecipes, setMenuRecipes] = useState([]);
+
+  function changePrice(start) {
+    const recipesData = start ? selectedRecipes : menuRecipes;
+    let price = 0;
+    recipesData.forEach((recipe) => {
+      if (recipe.selected) {
+        price += recipe.quantity * recipe.price;
+      }
+    });
+    setMenuTotalPrice(price);
+  }
+
+  useEffect(() => {
+    setSelectedRecipes([]);
+  }, []);
+
+  useEffect(() => {
+    setMenuRecipes(JSON.parse(JSON.stringify(selectedRecipes)));
+    changePrice(true);
+  }, [selectedRecipes]);
+
+  function removeRecipe(recipeId) {
+    const auxRecipes = menuRecipes;
+    const auxRecipe = auxRecipes.find((recipe) => recipe.id.toString() === recipeId.toString());
+    auxRecipe.selected = false;
+    setSelectedRecipes(auxRecipes);
+  }
+
+  function searchRecipes() {
+    setSelectedRecipes(menuRecipes);
+    navigation.navigate('Agregar Receta');
+  }
+
+  function handleSubmit() {
+    const body = {
+      name: menuName,
+      portions: Number(menuPortions),
+    };
+    if (!menu) {
+      body.menuRecipesAttributes = menuRecipes.filter((recipe) => (recipe.selected))
+        .map((recipe) => ({
+          recipeId: recipe.id,
+          recipeQuantity: recipe.quantity,
+        }));
+      createMenu(body)
+        .then((resp) => {
+          navigation.goBack();
+        });
+    }
+  }
 
   return (
     <View style={styles.mainContainer}>
@@ -32,17 +88,24 @@ function MenuForm(props) {
             <Text style={styles.title}>Recetas seleccionadas</Text>
           </View>
           <TouchableOpacity
-            onPress={() => navigation.navigate('Agregar Receta', {})}
+            onPress={searchRecipes}
             style={[styles.button, styles.searchButton]}>
             <Text style={styles.searchText}>Buscar Recetas</Text>
           </TouchableOpacity>
         </View>
-        {<RecipeRow key={0}/>}
-        {<RecipeRow key={1}/>}
+        {menuRecipes.map((recipe) => (recipe.selected ?
+          <RecipeRow
+            recipe={recipe}
+            select={false}
+            remove={removeRecipe}
+            changePrice={changePrice}
+            key={recipe.id}
+          /> : null
+        ))}
       </ScrollView>
       <View style={styles.totalMenuRow}>
         <Text style={styles.totalPriceText}>Total del Menú</Text>
-        <Text style={styles.totalPriceNumber}>${menuTotalPrice}</Text>
+        <Text style={styles.totalPriceNumber}>${Math.round(menuTotalPrice)}</Text>
       </View>
       <View style={styles.menuButtonsRow}>
         <View style={styles.twoButtonContainer}>
@@ -51,8 +114,8 @@ function MenuForm(props) {
           </TouchableOpacity>
         </View>
         <View style={styles.twoButtonContainer}>
-          <TouchableOpacity style={[styles.button, styles.actionButton]}>
-            <Text style={styles.actionText}>Crear Menú</Text>
+          <TouchableOpacity onPress={handleSubmit} style={[styles.button, styles.actionButton]}>
+            <Text style={styles.actionText}>{menu ? 'Editar Menú' : 'Crear Menú'}</Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/store/store.js
+++ b/store/store.js
@@ -232,6 +232,26 @@ const storeThunks = {
 
     return menus;
   }),
+  createMenu: thunk(async (actions, payload) => {
+    const menu = menusApi.createMenu(payload)
+      .then((resp) => resp.data)
+      .catch((err) => {
+        actions.setMenusError(err.response.data.message);
+        throw err;
+      });
+
+    return menu;
+  }),
+  editMenu: thunk(async (actions, payload) => {
+    const menu = menusApi.editMenu(payload)
+      .then((resp) => resp.data)
+      .catch((err) => {
+        actions.setMenusError(err.response.data.message);
+        throw err;
+      });
+
+    return menu;
+  }),
   getProviders: thunk(async (actions, payload) => {
     const providers = providersApi.getProviders(payload)
       .then((res) => res.data.data)

--- a/styles/Menus/form.js
+++ b/styles/Menus/form.js
@@ -170,6 +170,7 @@ const styles = StyleSheet.create({
     color: colors.yellow,
     fontSize: 20,
     fontWeight: 'bold',
+    paddingHorizontal: 10,
   },
 });
 


### PR DESCRIPTION
**Que se hizo**
* Se unió la componente de `recipeRow` entre las dos vistas de crear/editar menú. (con la variable `selected`).
* Se muestran las recetas ya seleccionadas junto con su cantidad real, nombre y precio según cantidad.
* Se calcula el precio total del menú y se actualiza con cada cambio.
* Se conectó `Crear Menú` con el backend.

**QA**
1. Entrar a la pestaña Menús, seleccionar el `+` de la esquina superior derecha 
![WhatsApp Image 2021-06-09 at 16 07 57](https://user-images.githubusercontent.com/42159846/121425174-1efe3c00-c940-11eb-8419-bc0414860aa5.jpeg)

2. Escribir un nombre y número de porciones para el menú
3. Seleccionar Recetas en `Buscar Recetas`
4.  Seleccionar las recetas a agregar y cambiar la cantidad, luego apretar `Guardar Cambios`.
![WhatsApp Image 2021-06-09 at 16 07 58](https://user-images.githubusercontent.com/42159846/121425274-389f8380-c940-11eb-8d0c-5c6d999386f6.jpeg)

5. Cambiar la cantidad de la receta, volver a agregar otras recetas o eliminar una con la `x`.
![WhatsApp Image 2021-06-09 at 16 07 58 (1)](https://user-images.githubusercontent.com/42159846/121425303-4228eb80-c940-11eb-8149-92a750db1ec7.jpeg)

6. Crear la receta. Buscarla en el index (en esta rama no está el index terminado y hay que cerrar sesión y volver a inicar para verla)
![WhatsApp Image 2021-06-09 at 16 07 59](https://user-images.githubusercontent.com/42159846/121425337-4a812680-c940-11eb-9a77-de693a27195f.jpeg)



**Por hacer**
* Crear la lógica para editar recetas con este mismo form
* Luego de aceptada la repuesta de la api, agregarla en el index.
* Implementar el buscador en seleccionar recetas.