### PR TITLE
Session routing errors

### DIFF
--- a/screens/LogInScreen.js
+++ b/screens/LogInScreen.js
@@ -4,8 +4,10 @@ import { Text, View, TextInput, TouchableOpacity } from 'react-native';
 import { useStoreState, useStoreActions } from 'easy-peasy';
 import styles from '../styles/authStyles';
 
-function LogIn(props) {
-  const { setLoginView } = props;
+function LogIn() {
+  //const { setLoginView } = props;
+  const setLoginView = useStoreActions((actions) => actions.setLoginView);
+  const setLoginError = useStoreActions((actions) => actions.setLoginError);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
@@ -23,6 +25,11 @@ function LogIn(props) {
       user: { email, password },
       logIn: true };
     login(body);
+  }
+
+  function goToSignUp() {
+    setLoginView(false);
+    setLoginError(false);
   }
 
   return (
@@ -53,7 +60,7 @@ function LogIn(props) {
         </TouchableOpacity>
 
         <TouchableOpacity
-          onPress={() => setLoginView(false)}>
+          onPress={goToSignUp}>
           <Text style={styles.haveAccountText}>
             ¿No tienes una cuenta? Regístrate!
           </Text>

--- a/screens/LogInScreen.js
+++ b/screens/LogInScreen.js
@@ -5,7 +5,6 @@ import { useStoreState, useStoreActions } from 'easy-peasy';
 import styles from '../styles/authStyles';
 
 function LogIn() {
-  //const { setLoginView } = props;
   const setLoginView = useStoreActions((actions) => actions.setLoginView);
   const setLoginError = useStoreActions((actions) => actions.setLoginError);
   const [email, setEmail] = useState('');

--- a/screens/Main.js
+++ b/screens/Main.js
@@ -8,7 +8,6 @@ import HomeTabs from '../navigators/bottomNavigation';
 
 function Main() {
   const currentUser = useStoreState((state) => state.currentUser);
-  //const [loginView, setLoginView] = useState(true);
   const loginView = useStoreState((state) => state.loginView);
 
   if (currentUser) {

--- a/screens/Main.js
+++ b/screens/Main.js
@@ -8,7 +8,8 @@ import HomeTabs from '../navigators/bottomNavigation';
 
 function Main() {
   const currentUser = useStoreState((state) => state.currentUser);
-  const [loginView, setLoginView] = useState(true);
+  //const [loginView, setLoginView] = useState(true);
+  const loginView = useStoreState((state) => state.loginView);
 
   if (currentUser) {
     return (
@@ -20,12 +21,12 @@ function Main() {
 
   if (loginView) {
     return (
-      <LogIn setLoginView={ setLoginView } />
+      <LogIn />
     );
   }
 
   return (
-    <SignUp setLoginView ={ setLoginView }/>
+    <SignUp />
   );
 }
 

--- a/screens/SignUpScreen.js
+++ b/screens/SignUpScreen.js
@@ -4,8 +4,10 @@ import { Text, View, TextInput, TouchableOpacity } from 'react-native';
 import { useStoreActions, useStoreState } from 'easy-peasy';
 import styles from '../styles/authStyles';
 
-function SignUp(props) {
-  const { setLoginView } = props;
+function SignUp() {
+  //const { setLoginView } = props;
+  const setLoginView = useStoreActions((actions) => actions.setLoginView);
+  const setSignUpError = useStoreActions((actions) => actions.setSignUpError);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [password2, setPassword2] = useState('');
@@ -28,6 +30,11 @@ function SignUp(props) {
     } else {
       setErrorMessage('Las contraseñas no coinciden');
     }
+  }
+
+  function goToLogin() {
+    setLoginView(true);
+    setSignUpError(false);
   }
 
   return (
@@ -60,7 +67,7 @@ function SignUp(props) {
           <Text style={styles.buttonText}>Registrarse</Text>
         </TouchableOpacity>
         <TouchableOpacity
-          onPress={() => setLoginView(true)}>
+          onPress={goToLogin}>
           <Text style={styles.haveAccountText}>
             ¿Ya tienes una cuenta? Inicia Sesión!
           </Text>

--- a/screens/SignUpScreen.js
+++ b/screens/SignUpScreen.js
@@ -5,7 +5,6 @@ import { useStoreActions, useStoreState } from 'easy-peasy';
 import styles from '../styles/authStyles';
 
 function SignUp() {
-  //const { setLoginView } = props;
   const setLoginView = useStoreActions((actions) => actions.setLoginView);
   const setSignUpError = useStoreActions((actions) => actions.setSignUpError);
   const [email, setEmail] = useState('');

--- a/store/store.js
+++ b/store/store.js
@@ -11,6 +11,7 @@ const storeState = {
   loginError: '',
   signUpError: '',
   ingredientsError: '',
+  loginView: true,
   recipes: {
     getErrors: '',
     createErrors: '',
@@ -38,6 +39,9 @@ const storeActions = {
   }),
   setSignUpError: action((state, payload) => {
     state.signUpError = payload;
+  }),
+  setLoginView: action((state, payload) => {
+    state.loginView = payload;
   }),
   setUserAndApiHeaders: action((state, payload) => {
     if (payload.status === apiUtils.statusCodes.ok || payload.status === apiUtils.statusCodes.created) {
@@ -77,6 +81,7 @@ const storeActions = {
   }),
   setLogOut: action((state) => {
     state.currentUser = null;
+    state.loginView = true;
     apiUtils.api.defaults.headers = { 'Accept': 'application/json',
       'Content-Type': 'application/json' };
   }),
@@ -90,6 +95,8 @@ const storeThunks = {
     sessionsApi.login(payload)
       .then((resp) => {
         actions.setUserAndApiHeaders(resp);
+        actions.setLoginError('');
+        actions.setLoginView(true);
       }).catch((error) => {
         actions.setLoginError(error.response.data.message);
       });
@@ -98,6 +105,7 @@ const storeThunks = {
     sessionsApi.signUp(payload)
       .then((resp) => {
         actions.setUserAndApiHeaders(resp);
+        actions.setSignUpError('');
       }).catch((error) => {
         actions.setSignUpError(error.response.data.message);
       });

--- a/store/store.js
+++ b/store/store.js
@@ -81,7 +81,6 @@ const storeActions = {
   }),
   setLogOut: action((state) => {
     state.currentUser = null;
-    state.loginView = true;
     apiUtils.api.defaults.headers = { 'Accept': 'application/json',
       'Content-Type': 'application/json' };
   }),
@@ -106,6 +105,7 @@ const storeThunks = {
       .then((resp) => {
         actions.setUserAndApiHeaders(resp);
         actions.setSignUpError('');
+        actions.setLoginView(true);
       }).catch((error) => {
         actions.setSignUpError(error.response.data.message);
       });


### PR DESCRIPTION
### Contexto

Al cerrar sesion, se redirigia al login, en caso de haberse logueado mediante login, y se redirigía al signup, en caso de haberse logueado de ahí. Además, los mensajes de error seguían seteados al cerrar sesión

### Qué hice

* Manejo de vista de login o signUp según estado almacenado en `store.js`
* Errores de login desaparecen al ir a signup y viceversa

### QA

* Ingresar credenciales inválidas en login, ir a signup y volver al login; no debiera mostrarse el mensaje de error de login
* Ingresar credenciales inválidas en signup,  ir a login y volver al signup; no debiera mostrarse el mensaje de error de signup
* ingresar credenciales inválidas en login, luego credenciales válidas también en login y cerrar sesión; debería aparecer la vista de login y sin mensajes de error, tanto en login como signup
* ingresar credenciales inválidas en signup, luego credenciales válidas también en signup y cerrar sesión; debería aparecer la vista de login y sin mensajes de error, tanto en login como signup