### PR TITLE
refactor(Provider): update providers screens to UI version

### DIFF
--- a/navigators/providersStack.js
+++ b/navigators/providersStack.js
@@ -3,6 +3,7 @@ import { createStackNavigator } from '@react-navigation/stack';
 import IndexProvider from '../screens/Providers/IndexProviderScreen';
 import FormProvider from '../screens/Providers/FormProviderScreen';
 import ShowProvider from '../screens/Providers/ShowProviderScreen';
+import colors from '../styles/appColors';
 
 const MainProvidersStack = createStackNavigator();
 
@@ -12,18 +13,40 @@ function ProvidersStackScreen() {
       <MainProvidersStack.Screen
         name="Proveedores"
         component={IndexProvider}
+        options={{ headerTintColor: colors.kitchengramWhite,
+          headerTitleAlign: 'left',
+          headerStyle: { backgroundColor: colors.kitchengramBlack,
+          } }}
       />
       <MainProvidersStack.Screen
         name="Nuevo Proveedor"
         component={FormProvider}
+        options={{ headerTintColor: colors.kitchengramWhite,
+          headerTitleAlign: 'center',
+          headerStyle: { backgroundColor: colors.kitchengramBlack,
+          },
+          headerBackTitleVisible: false,
+        }}
       />
       <MainProvidersStack.Screen
         name="Proveedor"
         component={ShowProvider}
+        options={{ headerTintColor: colors.kitchengramWhite,
+          headerTitleAlign: 'center',
+          headerStyle: { backgroundColor: colors.kitchengramBlack,
+          },
+          headerBackTitleVisible: false,
+        }}
       />
       <MainProvidersStack.Screen
         name="Editar Proveedor"
         component={FormProvider}
+        options={{ headerTintColor: colors.kitchengramWhite,
+          headerTitleAlign: 'center',
+          headerStyle: { backgroundColor: colors.kitchengramBlack,
+          },
+          headerBackTitleVisible: false,
+        }}
       />
     </MainProvidersStack.Navigator>
   );

--- a/screens/Providers/FormProviderScreen.js
+++ b/screens/Providers/FormProviderScreen.js
@@ -3,6 +3,7 @@ import React, {
 } from 'react';
 import {
   View,
+  ScrollView,
   TouchableOpacity,
   Text,
   TextInput,
@@ -89,81 +90,83 @@ function FormProvider({ navigation, route }) {
   }
 
   return (
-    <View style={styles.container}>
-      <View style={styles.inputContainer}>
-        <Text style={styles.inputLabel}>
+    <View>
+      <ScrollView style={styles.container}>
+        <View style={styles.inputContainer}>
+          <Text style={styles.inputLabel}>
             Nombre
-        </Text>
-        <TextInput
-          style={styles.input}
-          placeholder="Nombre de proveedor..."
-          value={name}
-          onChangeText={(text) => setName(text)}
-        />
-      </View>
-      <View style={styles.inputContainer}>
-        <Text style={styles.inputLabel}>
+          </Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Nombre de proveedor..."
+            value={name}
+            onChangeText={(text) => setName(text)}
+          />
+        </View>
+        <View style={styles.inputContainer}>
+          <Text style={styles.inputLabel}>
             Correo
-        </Text>
-        <TextInput
-          style={styles.input}
-          placeholder="Correo electrónico..."
-          autoCapitalize="none"
-          value={email}
-          onChangeText={(text) => setEmail(text)}
-        />
-      </View>
-      <View style={styles.inputContainer}>
-        <Text style={styles.inputLabel}>
+          </Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Correo electrónico..."
+            autoCapitalize="none"
+            value={email}
+            onChangeText={(text) => setEmail(text)}
+          />
+        </View>
+        <View style={styles.inputContainer}>
+          <Text style={styles.inputLabel}>
             Teléfono
-        </Text>
-        <TextInput
-          style={styles.input}
-          placeholder="Teléfono de contacto..."
-          keyboardType="number-pad"
-          returnKeyType='done'
-          value={phone}
-          onChangeText={(text) => setPhone(formatPhone(text))}
-        />
-      </View>
-      <View style={styles.inputContainer}>
-        <Text style={styles.inputLabel}>
+          </Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Teléfono de contacto..."
+            keyboardType="number-pad"
+            returnKeyType='done'
+            value={phone}
+            onChangeText={(text) => setPhone(formatPhone(text))}
+          />
+        </View>
+        <View style={styles.inputContainer}>
+          <Text style={styles.inputLabel}>
             Página Web
-        </Text>
-        <TextInput
-          style={styles.input}
-          placeholder="Página Web..."
-          autoCapitalize="none"
-          value={webpageUrl}
-          onChangeText={(text) => setWebpageUrl(text)}
-        />
-      </View>
-      <View style={styles.inputContainer}>
-        <Text style={styles.inputLabel}>
-            Tiempo de entrega
-        </Text>
-        <TextInput
-          style={styles.input}
-          placeholder="Tiempo de entrega..."
-          keyboardType="number-pad"
-          returnKeyType='done'
-          value={time ? time.toString() : 0}
-          onChangeText={(text) => setTime(text)}
-        />
-      </View>
-      <View style={styles.inputContainer}>
-        <Text style={styles.inputLabel}>
+          </Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Página Web..."
+            autoCapitalize="none"
+            value={webpageUrl}
+            onChangeText={(text) => setWebpageUrl(text)}
+          />
+        </View>
+        <View style={styles.inputContainer}>
+          <Text style={styles.inputLabel}>
+            Tiempo de entrega (días)
+          </Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Tiempo de entrega..."
+            keyboardType="number-pad"
+            returnKeyType='done'
+            value={time ? time.toString() : 0}
+            onChangeText={(text) => setTime(text)}
+          />
+        </View>
+        <View style={styles.inputContainer}>
+          <Text style={styles.inputLabel}>
             Mínimo de compra
-        </Text>
-        <TextInput
-          style={styles.input}
-          placeholder="Mínimo de compra..."
-          keyboardType="number-pad"
-          returnKeyType='done'
-          value={minPurchase ? minPurchase.toString() : 0}
-          onChangeText={(text) => setMinPurchase(text)}
-        />
-      </View>
+          </Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Mínimo de compra..."
+            keyboardType="number-pad"
+            returnKeyType='done'
+            value={minPurchase ? minPurchase.toString() : 0}
+            onChangeText={(text) => setMinPurchase(text)}
+          />
+        </View>
+      </ScrollView>
 
       <View style={styles.buttonsContainer}>
         <TouchableOpacity
@@ -184,6 +187,7 @@ function FormProvider({ navigation, route }) {
           </Text>
         </TouchableOpacity>
       </View>
+
     </View>
   );
 }

--- a/screens/Providers/IndexProviderScreen.js
+++ b/screens/Providers/IndexProviderScreen.js
@@ -79,7 +79,7 @@ function IndexProviders({ navigation }) {
             <View style={styles.right}>
               <Icon name='chevron-down'
                 size={20}
-                color={colors.black}
+                color={colors.kitchengramGray600}
               />
             </View>
           </TouchableOpacity>

--- a/screens/recipes/RecipeIngredientsScreen.js
+++ b/screens/recipes/RecipeIngredientsScreen.js
@@ -25,9 +25,9 @@ function RecipeIngredients(props) {
         const allIds = resp.map((ingred) => ingred.id.toString());
         const currentIds = actualSelection.map((i) => i.id.toString());
         setSelecteds(
-          currentIds.map(id => allIds.indexOf(id))
-        )
-      })
+          currentIds.map(id => allIds.indexOf(id)),
+        );
+      });
   }, []);
 
   function getIngredientsFromSearch() {
@@ -65,10 +65,10 @@ function RecipeIngredients(props) {
       if (!includedCondition && indexFoundAndEqualCondition) {
         deleteIngredientsIds.push(ingred.id);
       }
-    })
+    });
     setDeletedIngredient(deleteIngredientsIds);
-    let ingredientsForRecipe = ingredients.filter((_ingredient, index) => selecteds.includes(index));
-    setIngredientsForRecipe(ingredientsForRecipe)
+    const ingredientsForRecipe = ingredients.filter((_ingredient, index) => selecteds.includes(index));
+    setIngredientsForRecipe(ingredientsForRecipe);
     const backRoute = isNewRecipe === null ? 'Crear receta' : 'Editar Receta';
     navigation.navigate(backRoute);
   }

--- a/styles/Providers/formStyles.js
+++ b/styles/Providers/formStyles.js
@@ -3,33 +3,34 @@ import colors from '../appColors';
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#FFFFFF',
-    alignItems: 'center',
+    backgroundColor: colors.kitchengramWhite,
+    height: '87%',
     width: '100%',
-    height: '100%',
+    paddingTop: 15,
+    paddingHorizontal: '5%',
   },
 
   inputContainer: {
-    width: '75%',
-    height: '10%',
+    width: '100%',
+    height: 60,
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'flex-start',
-    marginTop: 22,
+    marginVertical: 15,
   },
 
   inputLabel: {
     fontSize: 14,
     fontWeight: 'normal',
     fontStyle: 'normal',
-    color: colors.tableBorder,
-    marginBottom: 3,
+    color: colors.kitchengramBlack,
+    marginBottom: 5,
   },
 
   input: {
     width: '100%',
-    height: '85%',
-    borderColor: colors.tableBorder,
+    height: 50,
+    borderColor: colors.kitchengramGray600,
     borderWidth: 2,
     borderRadius: 5,
     fontSize: 14,
@@ -37,59 +38,36 @@ const styles = StyleSheet.create({
     paddingRight: 15,
     fontWeight: 'bold',
     fontStyle: 'normal',
-    color: '#111111',
-  },
-
-  dropDown: {
-    width: '100%',
-    height: '85%',
-    borderColor: colors.tableBorder,
-    borderWidth: 2,
-    borderRadius: 5,
-    fontSize: 16,
+    color: colors.kitchengramBlack,
   },
 
   buttonsContainer: {
-    width: '100%',
-    height: '15%',
+    height: '13%',
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
+    justifyContent: 'space-between',
+    width: '100%',
+    paddingHorizontal: '5%',
+    paddingVertical: 10,
+    backgroundColor: colors.kitchengramWhite,
   },
 
   button: {
-    height: '40%',
+    height: '100%',
     alignItems: 'center',
     justifyContent: 'center',
   },
-
-  scrapperButton: {
-    backgroundColor: colors.greenButtons,
-    padding: 12,
-    borderRadius: 5,
-    height: '8%',
-    width: '75%',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginVertical: 10 },
-
-  scrapperButtonText: {
-    color: colors.white,
-    fontWeight: 'bold',
-  },
-
   cancel: {
-    width: '30%',
+    width: '48%',
     backgroundColor: 'transparent',
-    marginRight: 10,
+    borderWidth: 1,
+    borderRadius: 5,
+    borderColor: colors.kitchengramGray600,
   },
 
   confirm: {
-    width: '55%',
-    backgroundColor: colors.greenButtons,
+    width: '48%',
+    backgroundColor: colors.kitchengramGreen500,
     borderRadius: 5,
   },
 
@@ -100,11 +78,11 @@ const styles = StyleSheet.create({
   },
 
   cancelText: {
-    color: colors.greenButtons,
+    color: colors.kitchengramGray600,
   },
 
   confirmText: {
-    color: colors.white,
+    color: colors.kitchengramWhite,
   },
 });
 

--- a/styles/Providers/indexStyles.js
+++ b/styles/Providers/indexStyles.js
@@ -3,7 +3,7 @@ import colors from '../appColors';
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: colors.kitchengramWhite,
     flex: 1,
   },
 
@@ -13,14 +13,16 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'flex-start',
+    borderBottomColor: colors.kitchengramGray400,
+    borderBottomWidth: 1,
   },
 
   even: {
-    backgroundColor: '#EEEEEE',
+    backgroundColor: colors.kitchengramWhite,
   },
 
   odd: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: colors.kitchengramWhite,
   },
 
   left: {
@@ -34,7 +36,7 @@ const styles = StyleSheet.create({
 
   name: {
     fontSize: 20,
-    color: colors.black,
+    color: colors.kitchengramGray600,
     fontWeight: '500',
     fontStyle: 'normal',
     marginBottom: 10,
@@ -66,7 +68,7 @@ const styles = StyleSheet.create({
 
   navIcon: {
     paddingRight: 8,
-    color: colors.black,
+    color: colors.kitchengramWhite,
   },
 });
 

--- a/styles/showStyles.js
+++ b/styles/showStyles.js
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
   },
 
   name: {
-    width: '40%',
+    width: '35%',
     textAlign: 'left',
     fontSize: 14,
     color: colors.kitchengramGray600,
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
   },
 
   value: {
-    width: '60%',
+    width: '65%',
     textAlign: 'right',
     fontSize: 20,
     color: colors.kitchengramGray600,


### PR DESCRIPTION
Que se hizo: cambiar los estilos de las screens de proveedores de index y edit/create a los estilos de la UI.

QA: yendo a la pestaña de proveedores se debería ver algo así al tener proveedores disponibles:
![image](https://user-images.githubusercontent.com/42247208/121752391-062b8d00-cade-11eb-85c3-b61a7002d1e5.png)

si se pulsa el + del header se debería mostrar la vista de crear que debería verse algo así:
![image](https://user-images.githubusercontent.com/42247208/121752460-28bda600-cade-11eb-82f1-a22dfd73d105.png)

show es el mismo que en ingredientes por lo que no se incluye, al igual que el editar que es igual a la vista de crear

