### PR TITLE
Loading spinner

### DIFF
--- a/components/Spinner.js
+++ b/components/Spinner.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View, ActivityIndicator, Text } from 'react-native';
+import colors from '../styles/appColors';
+
+import styles from '../styles/spinnerStyles';
+
+function Spinner() {
+  return (
+    <View style={styles.activityIndicatorContainer}>
+      <ActivityIndicator
+        size="large"
+        color={colors.kitchengramYellow500}
+      />
+      <Text style={styles.activityIndicatorText}>
+        Cargando
+      </Text>
+    </View>
+  );
+}
+export default Spinner;

--- a/screens/Main.js
+++ b/screens/Main.js
@@ -1,31 +1,42 @@
 import React from 'react';
 import { useStoreState } from 'easy-peasy';
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer} from '@react-navigation/native';
 
 import LogIn from './LogInScreen';
 import SignUp from './SignUpScreen';
 import HomeTabs from '../navigators/bottomNavigation';
+import Spinner from '../components/Spinner';
 
 function Main() {
   const currentUser = useStoreState((state) => state.currentUser);
   const loginView = useStoreState((state) => state.loginView);
+  const showLoadingSpinner = useStoreState((state) => state.showLoadingSpinner);
 
   if (currentUser) {
     return (
-      <NavigationContainer>
-        <HomeTabs />
-      </NavigationContainer>
+      <>
+        <NavigationContainer>
+          <HomeTabs />
+        </NavigationContainer>
+        {showLoadingSpinner && <Spinner /> }
+      </>
     );
   }
 
   if (loginView) {
     return (
-      <LogIn />
+      <>
+        <LogIn />
+        {/* {showLoadingSpinner && <Spinner /> } */}
+      </>
     );
   }
 
   return (
-    <SignUp />
+    <>
+      <SignUp />
+      {showLoadingSpinner && <Spinner /> }
+    </>
   );
 }
 

--- a/screens/Main.js
+++ b/screens/Main.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useStoreState } from 'easy-peasy';
-import { NavigationContainer} from '@react-navigation/native';
+import { NavigationContainer } from '@react-navigation/native';
 
 import LogIn from './LogInScreen';
 import SignUp from './SignUpScreen';
@@ -27,7 +27,7 @@ function Main() {
     return (
       <>
         <LogIn />
-        {/* {showLoadingSpinner && <Spinner /> } */}
+        {showLoadingSpinner && <Spinner /> }
       </>
     );
   }

--- a/screens/Providers/FormProviderScreen.js
+++ b/screens/Providers/FormProviderScreen.js
@@ -42,26 +42,24 @@ function FormProvider({ navigation, route }) {
   const editProvider = useStoreActions((actions) => actions.editProvider);
 
   function checkValidInputs() {
-
     const validations = [
-      { error: !name.length, message: "Debes asignar un nombre al proveedor" },
-      { error: !email.length, message: "Debes ingresar un email válido." },
-      { error: time <= 0, message: "Debes ingresar un tiempo válido" },
-      { error: minPurchase <= 0, message: "Debes ingresar un mínimo de compra válido" },
+      { error: !name.length, message: 'Debes asignar un nombre al proveedor' },
+      { error: !email.length, message: 'Debes ingresar un email válido.' },
+      { error: time <= 0, message: 'Debes ingresar un tiempo válido' },
+      { error: minPurchase <= 0, message: 'Debes ingresar un mínimo de compra válido' },
     ];
     const error = validations.find((validation) => (validation.error));
     if (error) {
       alert(error.message);
-      return false
+
+      return false;
     }
 
     return true;
   }
 
-
   function handleSubmit(create) {
-
-   if (!checkValidInputs()) return;
+    if (!checkValidInputs()) return;
 
     const attributes = {
       name,

--- a/screens/recipes/NewRecipeScreen.js
+++ b/screens/recipes/NewRecipeScreen.js
@@ -168,26 +168,24 @@ function FormRecipe(props) {
   }
 
   function checkValidInputs() {
-
     const validations = [
-      { error: !recipeName.length, message: "Debes asignar un nombre a la receta" },
-      { error: recipePortions <= 0, message: "Debes ingresar porciones válidas" },
-      { error: recipeTime <= 0, message: "Debes ingresar un tiempo de preparación válida" },
-      { error: !recipeIngredients.length, message: "Debes ingresar uno o más ingredientes" },
-      { error: !recipeSteps.length, message: "Debes ingresar uno o más pasos" },
+      { error: !recipeName.length, message: 'Debes asignar un nombre a la receta' },
+      { error: recipePortions <= 0, message: 'Debes ingresar porciones válidas' },
+      { error: recipeTime <= 0, message: 'Debes ingresar un tiempo de preparación válida' },
+      { error: !recipeIngredients.length, message: 'Debes ingresar uno o más ingredientes' },
+      { error: !recipeSteps.length, message: 'Debes ingresar uno o más pasos' },
     ];
     const error = validations.find((validation) => (validation.error));
     if (error) {
       alert(error.message);
-      return false
+
+      return false;
     }
 
     return true;
   }
 
-
   function handleSubmit() {
-
     if (!checkValidInputs()) return;
 
     const body = {

--- a/store/store.js
+++ b/store/store.js
@@ -99,14 +99,15 @@ const storeActions = {
   setLoadRecipes: action((state, payload) => {
     state.recipes.load = payload;
   }),
-  setShowLoadingSpinner: action((state, payload) => {
-    state.showLoadingSpinner = payload;
+  setShowLoadingSpinner: action((state) => {
+    state.showLoadingSpinner = !state.showLoadingSpinner;
   }),
 };
 
 const storeThunks = {
   login: thunk(async (actions, payload) => {
-    sessionsApi.login(payload)
+    actions.setShowLoadingSpinner();
+    await sessionsApi.login(payload)
       .then((resp) => {
         actions.setUserAndApiHeaders(resp);
         actions.setLoginError('');
@@ -114,9 +115,11 @@ const storeThunks = {
       }).catch((error) => {
         actions.setLoginError(error.response.data.message);
       });
+    actions.setShowLoadingSpinner();
   }),
   signUp: thunk(async (actions, payload) => {
-    sessionsApi.signUp(payload)
+    actions.setShowLoadingSpinner();
+    await sessionsApi.signUp(payload)
       .then((resp) => {
         actions.setUserAndApiHeaders(resp);
         actions.setSignUpError('');
@@ -124,80 +127,98 @@ const storeThunks = {
       }).catch((error) => {
         actions.setSignUpError(error.response.data.message);
       });
+    actions.setShowLoadingSpinner();
   }),
   getIngredients: thunk(async (actions, payload) => {
-    const ingredients = ingredientsApi.getIngredients(payload)
+    actions.setShowLoadingSpinner();
+    const ingredients = await ingredientsApi.getIngredients(payload)
       .then((res) => camelizeKeys(res.data.data))
       .catch((err) => {
         actions.setIngredientsError(err.response.data.message);
         throw err;
       });
+    actions.setShowLoadingSpinner();
 
     return ingredients;
   }),
   createIngredient: thunk(async (actions, payload) => {
-    const ingredient = ingredientsApi.createIngredient(payload)
+    actions.setShowLoadingSpinner();
+    const ingredient = await ingredientsApi.createIngredient(payload)
       .then((res) => camelizeKeys(res.data.data))
       .catch((err) => {
         actions.setIngredientsError(err.response.data.message);
         throw err;
       });
+    actions.setShowLoadingSpinner();
 
     return ingredient;
   }),
   editIngredient: thunk(async (actions, payload) => {
-    ingredientsApi.editIngredient(payload)
+    actions.setShowLoadingSpinner();
+    await ingredientsApi.editIngredient(payload)
       .catch((err) => {
         actions.setIngredientsError(err.response.data.message);
         throw err;
       });
+    actions.setShowLoadingSpinner();
   }),
   deleteIngredient: thunk(async (actions, payload) => {
-    ingredientsApi.deleteIngredient(payload)
+    actions.setShowLoadingSpinner();
+    await ingredientsApi.deleteIngredient(payload)
       .catch((err) => {
         actions.setIngredientsError(err.response.data.message);
         throw err;
       });
+    actions.setShowLoadingSpinner();
   }),
   searchCornerShop: thunk(async (actions, payload) => {
-    const ingredients = ingredientsApi.searchCornerShop(payload)
+    actions.setShowLoadingSpinner();
+    const ingredients = await ingredientsApi.searchCornerShop(payload)
       .then((res) => res.data.data)
       .catch((err) => {
         actions.setIngredientsError(err.response.data.message);
       });
+    actions.setShowLoadingSpinner();
 
     return ingredients;
   }),
   getRecipes: thunk(async (actions, payload) => {
-    const recipes = recipesApi.getRecipes(payload)
+    actions.setShowLoadingSpinner();
+    const recipes = await recipesApi.getRecipes(payload)
       .then((res) => res.data.data)
       .catch((err) => {
         actions.setGetRecipesError(err.response.data.message);
         throw err;
       });
+    actions.setShowLoadingSpinner();
 
     return recipes;
   }),
   createRecipe: thunk(async (actions, payload) => {
-    const recipe = recipesApi.createRecipe(payload)
+    actions.setShowLoadingSpinner();
+    const recipe = await recipesApi.createRecipe(payload)
       .then((resp) => resp)
       .catch((err) => {
         actions.setCreateRecipeError(err.response.data.message);
       });
+    actions.setShowLoadingSpinner();
 
     return recipe;
   }),
   editRecipe: thunk(async (actions, payload) => {
-    recipesApi.editRecipe(payload)
+    actions.setShowLoadingSpinner();
+    await recipesApi.editRecipe(payload)
       .then((resp) => resp.data)
       .catch((err) => {
         actions.setEditRecipeError(err.response.data.message);
 
         throw err;
       });
+    actions.setShowLoadingSpinner();
   }),
   deleteRecipe: thunk(async (actions, payload) => {
-    recipesApi.deleteRecipe(payload)
+    actions.setShowLoadingSpinner();
+    await recipesApi.deleteRecipe(payload)
       .then(() => {
         actions.setDeletedRecipe(true);
       })
@@ -205,116 +226,141 @@ const storeThunks = {
         actions.setDeleteRecipeError(err);
         throw err;
       });
+    actions.setShowLoadingSpinner();
   }),
 
   createRecipeStep: thunk(async (actions, payload) => {
-    const step = recipesApi.createRecipeStep(payload)
+    actions.setShowLoadingSpinner();
+    const step = await recipesApi.createRecipeStep(payload)
       .then((resp) => resp.data.data)
       .catch((err) => {
         actions.setEditRecipeError(err.response.data.message);
 
         throw err;
       });
+    actions.setShowLoadingSpinner();
 
     return step;
   }),
   editRecipeStep: thunk(async (actions, payload) => {
-    const step = recipesApi.editRecipeStep(payload)
+    actions.setShowLoadingSpinner();
+    const step = await recipesApi.editRecipeStep(payload)
       .then((resp) => resp.data)
       .catch((err) => {
         actions.setEditRecipeError(err.response.data.message);
 
         throw err;
       });
+    actions.setShowLoadingSpinner();
 
     return step;
   }),
   deleteRecipeStep: thunk(async (actions, payload) => {
-    const resp = recipesApi.deleteRecipeStep(payload)
+    actions.setShowLoadingSpinner();
+    const resp = await recipesApi.deleteRecipeStep(payload)
       .then((res) => res.data)
       .catch((err) => {
         actions.setEditRecipeError(err);
         throw err;
       });
+    actions.setShowLoadingSpinner();
 
     return resp;
   }),
   getMenus: thunk(async (actions, payload) => {
-    const menus = menusApi.getMenus(payload)
+    actions.setShowLoadingSpinner();
+    const menus = await menusApi.getMenus(payload)
       .then((res) => res.data.data)
       .catch((err) => {
         actions.setMenusError(err.response.data.message);
         throw err;
       });
+    actions.setShowLoadingSpinner();
 
     return menus;
   }),
   getMenu: thunk(async (actions, payload) => {
-    const menu = menusApi.getMenu(payload)
+    actions.setShowLoadingSpinner();
+    const menu = await menusApi.getMenu(payload)
       .then((res) => res.data.data)
       .catch((err) => {
         actions.setMenusError(err.response.data.message);
         throw err;
       });
+    actions.setShowLoadingSpinner();
 
     return menu;
   }),
   deleteMenu: thunk(async (actions, payload) => {
-    menusApi.deleteMenu(payload)
+    actions.setShowLoadingSpinner();
+    await menusApi.deleteMenu(payload)
       .catch((err) => {
         actions.setMenusError(err);
         throw err;
       });
+    actions.setShowLoadingSpinner();
   }),
   createMenu: thunk(async (actions, payload) => {
-    const menu = menusApi.createMenu(payload)
+    actions.setShowLoadingSpinner();
+    const menu = await menusApi.createMenu(payload)
       .then((resp) => resp.data)
       .catch((err) => {
         actions.setMenusError(err.response.data.message);
         throw err;
       });
+    actions.setShowLoadingSpinner();
 
     return menu;
   }),
   editMenu: thunk(async (actions, payload) => {
-    const menu = menusApi.editMenu(payload)
+    actions.setShowLoadingSpinner();
+    const menu = await menusApi.editMenu(payload)
       .then((resp) => resp.data)
       .catch((err) => {
         actions.setMenusError(err.response.data.message);
         throw err;
       });
+    actions.setShowLoadingSpinner();
 
     return menu;
   }),
   getProviders: thunk(async (actions, payload) => {
-    const providers = providersApi.getProviders(payload)
+    actions.setShowLoadingSpinner();
+    const providers = await providersApi.getProviders(payload)
       .then((res) => res.data.data)
       .catch((err) => {
         actions.setProvidersError(err.response.data.message);
         throw err;
       });
+    actions.setShowLoadingSpinner();
 
     return providers;
   }),
   createProvider: thunk(async (actions, payload) => {
-    const provider = providersApi.createProvider(payload)
+    actions.setShowLoadingSpinner();
+    const provider = await providersApi.createProvider(payload)
       .then((res) => res.data.data);
+    actions.setShowLoadingSpinner();
 
     return provider;
   }),
   deleteProvider: thunk(async (actions, payload) => {
-    providersApi.deleteProvider(payload)
+    actions.setShowLoadingSpinner();
+    await providersApi.deleteProvider(payload)
       .catch((err) => {
         actions.setProvidersError(err.response.data.message);
         throw err;
       });
+    actions.setShowLoadingSpinner();
   }),
   editProvider: thunk(async (actions, payload) => {
-    providersApi.editProvider(payload)
+    actions.setShowLoadingSpinner();
+    await providersApi.editProvider(payload)
       .catch((err) => {
         actions.setProvidersError(err.response.data.message);
         throw err;
       });
+    actions.setShowLoadingSpinner();
   }),
 };
 

--- a/store/store.js
+++ b/store/store.js
@@ -1,11 +1,11 @@
 import { createStore, action, thunk } from 'easy-peasy';
+import { camelizeKeys } from 'humps';
 import apiUtils from '../api/api';
 import sessionsApi from '../api/sessions';
 import ingredientsApi from '../api/ingredients';
 import recipesApi from '../api/recipes';
 import menusApi from '../api/menus';
 import providersApi from '../api/providers';
-import { camelizeKeys } from 'humps';
 
 const storeState = {
   currentUser: null,
@@ -28,6 +28,7 @@ const storeState = {
   },
   menusError: '',
   providersError: '',
+  showLoadingSpinner: false,
 };
 
 const getters = {
@@ -97,6 +98,9 @@ const storeActions = {
   }),
   setLoadRecipes: action((state, payload) => {
     state.recipes.load = payload;
+  }),
+  setShowLoadingSpinner: action((state, payload) => {
+    state.showLoadingSpinner = payload;
   }),
 };
 

--- a/styles/spinnerStyles.js
+++ b/styles/spinnerStyles.js
@@ -1,0 +1,21 @@
+import { StyleSheet } from 'react-native';
+import colors from './appColors'
+
+const styles = StyleSheet.create({
+  activityIndicatorContainer: {
+    height: '100%',
+    width: '100%',
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    position: 'absolute',
+    top: 0,
+    right: 0,
+  },
+  activityIndicatorText: {
+    paddingTop: 15,
+    color: colors.kitchengramWhite,
+  },
+});
+
+export default styles;

--- a/styles/spinnerStyles.js
+++ b/styles/spinnerStyles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import colors from './appColors'
+import colors from './appColors';
 
 const styles = StyleSheet.create({
   activityIndicatorContainer: {


### PR DESCRIPTION
Que se hizo:
- implementar un spinner cuando se está cargando cualquier cosa desde la api, para esto se creó una acción en el store que modifica el estado showLoadingSpinner a true cada vez que se llama a un thunk y al terminar lo pasa a false.
- arreglar algunos problemas que arrojaba el linter en otros archivos

QA: 
al intentar cargar cualquier cosa en la app deberia verse así:
![Screenshot from 2021-06-22 15-37-19](https://user-images.githubusercontent.com/42247208/122991224-c896f180-d372-11eb-8554-89b2263e3551.png)
Se puede ver al iniciar sesión o seleccionando cualquiera de los tabs inferiores de la app. Donde es más notorio es al buscar ingredientes del scrapper que cada vez que se hace una busqueda se deben cargar desde la api.