### PR TITLE
Refresh control

### DIFF
--- a/screens/Ingredients/IndexIngredientScreen.js
+++ b/screens/Ingredients/IndexIngredientScreen.js
@@ -66,7 +66,6 @@ function IndexIngredients({ navigation }) {
             <RefreshControl
               refreshing={refreshing}
               onRefresh={onRefresh}
-              colors={[colors.kitchengramYellow500]}
             />
           }>
           {ingredients.map((ingredient, i) => (

--- a/screens/Ingredients/IndexIngredientScreen.js
+++ b/screens/Ingredients/IndexIngredientScreen.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 import React, {
   useEffect,
   useState,
@@ -7,6 +8,7 @@ import {
   TouchableOpacity,
   Text,
   ScrollView,
+  RefreshControl,
 } from 'react-native';
 import { useStoreActions } from 'easy-peasy';
 import Icon from 'react-native-vector-icons/Ionicons';
@@ -16,10 +18,10 @@ import formatMoney from '../../utils/formatMoney';
 
 function IndexIngredients({ navigation }) {
   const getIngredients = useStoreActions((actions) => actions.getIngredients);
-
   const [ingredients, setIngredients] = useState([]);
   const evenNumber = 2;
   const [mounted, setMounted] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   useEffect(() => {
     getIngredients()
@@ -47,10 +49,26 @@ function IndexIngredients({ navigation }) {
       ),
     });
   }, [navigation, ingredients]);
+
+  function onRefresh() {
+    setRefreshing(true);
+    getIngredients()
+      .then((res) => {
+        setIngredients(res);
+      });
+    setRefreshing(false);
+  }
   if (ingredients.length) {
     return (
       <View style={styles.container}>
-        <ScrollView>
+        <ScrollView
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              colors={[colors.kitchengramYellow500]}
+            />
+          }>
           {ingredients.map((ingredient, i) => (
             <TouchableOpacity
               style={[styles.ingredientRow, (i % evenNumber === 0) ? styles.even : styles.odd]}

--- a/screens/Menus/MenusScreen.js
+++ b/screens/Menus/MenusScreen.js
@@ -3,7 +3,7 @@ import React, {
   useState,
 } from 'react';
 import { useStoreActions, useStoreState } from 'easy-peasy';
-import { Text, ScrollView, View } from 'react-native';
+import { Text, ScrollView, View, RefreshControl } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
 import MenuRow from '../../components/menuRow';
 import styles from '../../styles/Menus/indexStyles';
@@ -17,6 +17,16 @@ function Menus({ navigation }) {
 
   const [mounted, setMounted] = useState(false);
   const [menus, setMenus] = useState([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  function onRefresh() {
+    setRefreshing(true);
+    getMenus()
+      .then((res) => {
+        setGlobalMenus(res);
+      });
+    setRefreshing(false);
+  }
 
   React.useLayoutEffect(() => {
     navigation.setOptions({
@@ -54,7 +64,13 @@ function Menus({ navigation }) {
   if (menus.length && mounted) {
     return (
       <View style={styles.container}>
-        <ScrollView>
+        <ScrollView
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+            />
+          }>
           {menus.map((menu) => (
             <MenuRow
               key={menu.id}

--- a/screens/Providers/IndexProviderScreen.js
+++ b/screens/Providers/IndexProviderScreen.js
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   Text,
   ScrollView,
+  RefreshControl,
 } from 'react-native';
 import { useStoreActions } from 'easy-peasy';
 import Icon from 'react-native-vector-icons/Ionicons';
@@ -17,6 +18,16 @@ function IndexProviders({ navigation }) {
   const getProviders = useStoreActions((actions) => actions.getProviders);
   const [mounted, setMounted] = useState(false);
   const [providers, setProviders] = useState([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  function onRefresh() {
+    setRefreshing(true);
+    getProviders()
+      .then((res) => {
+        setProviders(res);
+      });
+    setRefreshing(false);
+  }
 
   React.useLayoutEffect(() => {
     navigation.setOptions({
@@ -48,7 +59,13 @@ function IndexProviders({ navigation }) {
   if (providers.length) {
     return (
       <View style={styles.container}>
-        <ScrollView>
+        <ScrollView
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+            />
+          }>
           {providers.map((provider, i) => (
             <TouchableOpacity
               // eslint-disable-next-line no-magic-numbers

--- a/screens/Recipes/RecipesScreen.js
+++ b/screens/Recipes/RecipesScreen.js
@@ -1,5 +1,6 @@
+/* eslint-disable max-statements */
 import React, { useEffect, useState } from 'react';
-import { Text, ScrollView } from 'react-native';
+import { Text, ScrollView, RefreshControl } from 'react-native';
 import { useStoreActions } from 'easy-peasy';
 import { Icon } from 'react-native-elements';
 import colors from '../../styles/appColors';
@@ -13,6 +14,16 @@ function Recipes(props) {
   const [_showError, setShowError] = useState(false);
   const [_errorMessage, setErrorMessage] = useState('');
   const [mounted, setMounted] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+
+  function onRefresh() {
+    setRefreshing(true);
+    getRecipes()
+      .then((res) => {
+        setRecipes(res);
+      });
+    setRefreshing(false);
+  }
 
   useEffect(() => {
     getRecipes()
@@ -48,7 +59,12 @@ function Recipes(props) {
 
   if (mounted && recipes.length) {
     return (
-      <ScrollView>
+      <ScrollView refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+        />
+      }>
         {recipes.map((recipe) => (
           <RecipeRow
             key={recipe.id}


### PR DESCRIPTION
Que se hizo: 
- se implemento refresh al deslizar hacia abajo (con RefreshControl) en las vistas de index de: ingredientes, recetes, menús y proveedores.

QA: ingresar con una misma cuenta en 2 disposittivos distintos. Crear, editar o eliminar un elemento en uno de los dispositivos y deslizar hacia abajo en el index del elemento respectivo en el otro dispositivo. Se debería visualizar el cambio.

![image](https://user-images.githubusercontent.com/42247208/123185654-69b1a500-d464-11eb-9774-6d830921c294.png)
Imagen de referencia en android