### PR TITLE
feat(ingredients):add equivalent measures

### DIFF
--- a/api/ingredients.js
+++ b/api/ingredients.js
@@ -11,6 +11,15 @@ const ingredientsApi = {
       data: payload,
     });
   },
+  getIngredient: (payload) => {
+    const url = `${config.endpoints.ingredients.specific}${payload.id}`;
+
+    return apiUtils.api({
+      method: 'get',
+      url,
+      data: payload.body,
+    });
+  },
   createIngredient: (payload) => {
     const url = config.endpoints.ingredients.index;
 

--- a/components/IngredientMeasureRow.js
+++ b/components/IngredientMeasureRow.js
@@ -1,0 +1,106 @@
+import React, { useState, useEffect } from 'react';
+import { Text, TextInput, View } from 'react-native';
+import RNPickerSelect from 'react-native-picker-select';
+import Icon from 'react-native-vector-icons/Ionicons';
+
+import styles from '../styles/Ingredients/formStyles';
+import pickers from '../styles/customPickerStyles';
+import colors from '../styles/appColors';
+
+function IngredientMeasureRow({ measure, handleMeasureChange, isDefault, hasLabels }) {
+  const [measuresOptions, setMeasuresOptions] = useState(['Unidad', 'Kilo', 'Gramo', 'Litro', 'Mililitro',
+    'Oz', 'Taza', 'Cucharada', 'Cucharadita', 'Otra']);
+  const [measureName, setMeasureName] = useState(measure.name);
+  const [otherMeasureSelected, setOtherMeasureSelected] = useState(false);
+  const [otherMeasureName, setOtherMeasureName] = useState('');
+
+  useEffect(() => {
+    if (measure.name && !measuresOptions.includes(measure.name)) {
+      setMeasuresOptions([measure.name, ...measuresOptions]);
+    }
+    if (measure.name === 'Otra') setOtherMeasureSelected(true);
+    else setOtherMeasureSelected(false);
+    setMeasureName(measure.name);
+  }, [measure, measuresOptions, measure.name]);
+
+  function handleNewMeasure() {
+    if (!otherMeasureName) return;
+    handleMeasureChange({ name: otherMeasureName });
+    setOtherMeasureName('');
+  }
+
+  return (
+    <>
+      <View style={styles.rowContainer}>
+        <View style={styles.inputUnitContainer}>
+          { hasLabels ?
+            <Text style={styles.inputLabel}>
+              Cantidad
+            </Text> : null
+          }
+          <TextInput
+            style={styles.input}
+            placeholder="Cantidad de ingrediente..."
+            keyboardType="number-pad"
+            returnKeyType='done'
+            value={measure.quantity.toString()}
+            onChangeText={(text) => handleMeasureChange({ quantity: text })}
+          />
+        </View>
+        <View style={styles.inputUnitContainer}>
+          {hasLabels ?
+            <Text style={styles.inputLabel}>
+              Unidad
+            </Text> : null
+          }
+          <View style={styles.dropDown}>
+            <RNPickerSelect
+              style={pickers.customPickerStyles}
+              key={'-1'}
+              placeholder={{
+                label: 'Seleccionar',
+                value: '',
+              }}
+              value={measureName}
+              onValueChange={(value) => handleMeasureChange({ name: value })}
+              items={measuresOptions.map((name, index) => ({ label: name, value: name, key: index }))}
+              Icon={() => <Icon name='chevron-down' size={27} color={colors.kitchengramGray600} />}
+            />
+
+          </View>
+        </View>
+        {isDefault ? null :
+          <View>
+            <Icon name='close-outline'
+              size={30}
+              color={colors.kitchengramGray600}
+              onPress={() => handleMeasureChange({ isRemoved: true })}
+            />
+          </View>
+        }
+      </View>
+      {otherMeasureSelected ?
+        <View style={styles.rowContainer}>
+          <View style={styles.inputNewMeasureContainer}>
+            <TextInput
+              style={styles.input}
+              placeholder="Nombre de Medida..."
+              returnKeyType='done'
+              value={otherMeasureName}
+              onChangeText={setOtherMeasureName}
+            />
+          </View>
+          <View>
+            <Icon name='checkmark-outline'
+              size={30}
+              color={colors.kitchengramGreen500}
+              onPress={() => handleNewMeasure()}
+            />
+          </View>
+        </View> : null
+      }
+    </>
+  );
+}
+
+export default IngredientMeasureRow;

--- a/screens/Ingredients/FormIngredientScreen.js
+++ b/screens/Ingredients/FormIngredientScreen.js
@@ -18,6 +18,7 @@ import styles from '../../styles/Ingredients/formStyles';
 import pickers from '../../styles/customPickerStyles';
 import colors from '../../styles/appColors';
 import KeyboardAvoidWrapper from '../../components/KeyboardAvoidWrapper';
+import IngredientMeasureRow from '../../components/IngredientMeasureRow';
 
 function FormIngredient({ navigation, route }) {
   const {
@@ -27,16 +28,6 @@ function FormIngredient({ navigation, route }) {
       attributes: {
         name: '',
         price: 0,
-        quantity: 0,
-        measure: '',
-        otherMeasures: {
-          data: [{
-            attributes: {
-              quantity: 0,
-            },
-          }],
-
-        },
         sku: '',
         currency: 'CLP',
         providerName: null,
@@ -46,6 +37,7 @@ function FormIngredient({ navigation, route }) {
     setIngredients,
   } = route.params;
 
+  const getIngredient = useStoreActions((actions) => actions.getIngredient);
   const createIngredient = useStoreActions((actions) => actions.createIngredient);
   const editIngredient = useStoreActions((actions) => actions.editIngredient);
   const getProviders = useStoreActions((actions) => actions.getProviders);
@@ -53,10 +45,14 @@ function FormIngredient({ navigation, route }) {
 
   const [name, setName] = useState(ingredient.attributes.name);
   const [price, setPrice] = useState(ingredient.attributes.price);
-  const [quantity, setQuantity] = useState(ingredient.attributes.otherMeasures.data[
-    ingredient.attributes.otherMeasures.data.length - 1
-  ].attributes.quantity);
-  const [measure, setMeasure] = useState(ingredient.attributes.measure);
+  const [measures, setMeasures] = useState(isNew ? [{ id: 0, name: '', quantity: '', isNew: true }] :
+    ingredient.attributes.otherMeasures.data.map(thisMeasure => ({
+      id: thisMeasure.id,
+      name: thisMeasure.attributes.name,
+      quantity: thisMeasure.attributes.quantity,
+      isNew: false,
+      isRemoved: false,
+    })));
   const [providerName, setProviderName] = useState(ingredient.attributes.providerName);
   const [providersNames, setProvidersNames] = useState([]);
 
@@ -76,12 +72,56 @@ function FormIngredient({ navigation, route }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  function handleMeasureChange(id, newMeasureAttributes) {
+    const toChangeMeasureIndex = measures.findIndex((thisMeasure) => thisMeasure.id === id);
+    if (toChangeMeasureIndex === -1) return;
+    setMeasures([
+      ...measures.slice(0, toChangeMeasureIndex),
+      { ...measures[toChangeMeasureIndex], ...newMeasureAttributes },
+      ...measures.slice(toChangeMeasureIndex + 1),
+    ]);
+  }
+
+  function addNewMeasure() {
+    setMeasures([
+      ...measures,
+      {
+        id: Math.max(...measures.map(thisMeasure => Number(thisMeasure.id)), 0) + 1,
+        name: '',
+        quantity: '',
+        isNew: true,
+        isRemoved: false,
+      },
+    ]);
+  }
+
+  function measureData(thisMeasure, primary) {
+    if (thisMeasure.isNew) {
+      if (!thisMeasure.isRemoved) return { name: thisMeasure.name, quantity: thisMeasure.quantity, primary };
+    } else if (thisMeasure.isRemoved) return { id: Number(thisMeasure.id), _destroy: true };
+    else if (!thisMeasure.isRemoved) return { ...thisMeasure, id: Number(thisMeasure.id), _destroy: false, primary };
+
+    return null;
+  }
+
+  function selectMeasuresToModify() {
+    return measures.map((thisMeasure, idx) => measureData(thisMeasure, !idx)).filter(thisMeasure => thisMeasure);
+  }
+
   function checkValidValues() {
     const validations = [
       { error: !name.length, message: 'Debes asignar un nombre al ingrediente' },
       { error: price <= 0, message: 'Debes ingresar un precio válido' },
-      { error: quantity <= 0, message: 'Debes ingresar una cantidad válida' },
-      { error: !measure.length, message: 'Debes ingresar una medida al ingrediente' },
+      { error: measures[0].quantity <= 0, message: 'Debes ingresar una cantidad por defecto' },
+      { error: !measures[0].name, message: 'Debes ingresar una medida por defecto' },
+      ...measures.slice(1).map(thisMeasure => ({
+        error: !thisMeasure.isRemoved && !thisMeasure.name,
+        message: 'Debes ingresar una medida a la unidad equivalente',
+      })),
+      ...measures.slice(1).map(thisMeasure => ({
+        error: !thisMeasure.isRemoved && !thisMeasure.quantity,
+        message: 'Debes ingresar una cantidad válida a la unidad equivalente',
+      })),
     ];
     const error = validations.find((validation) => (validation.error));
     if (error) {
@@ -96,36 +136,20 @@ function FormIngredient({ navigation, route }) {
   function handleSubmitNew() {
     if (!checkValidValues()) return;
 
-    const attributes = {
-      name,
-      sku: ingredient.attributes.sku,
-      price,
-      currency: ingredient.attributes.currency,
-      ingredientMeasuresAttributes: [{
-        quantity,
-        name: measure,
-      }],
-      quantity,
-      measure,
-      otherMeasures: {
-        data: [{
-          attributes: {
-            quantity,
-            name: measure,
-          },
-        }],
-      },
-      providerName,
-    };
-    ingredient.attributes = attributes;
     const body = {
-      ingredient: ingredient.attributes,
+      ingredient: {
+        name,
+        sku: ingredient.attributes.sku,
+        price,
+        currency: ingredient.attributes.currency,
+        ingredientMeasuresAttributes: selectMeasuresToModify(),
+        providerName,
+      },
     };
+
     createIngredient(body)
       .then((res) => {
-        const auxIngredients = [...ingredients];
-        auxIngredients.push(res);
-        setIngredients(auxIngredients);
+        setIngredients([...ingredients, res]);
         if (isFromSearch) {
           setChargeProviders();
         }
@@ -137,36 +161,22 @@ function FormIngredient({ navigation, route }) {
 
   function handleSubmitEdit() {
     if (!checkValidValues()) return;
-
-    const attributes = {
-      name,
-      sku: ingredient.attributes.sku,
-      price,
-      currency: ingredient.attributes.currency,
-      ingredientMeasuresAttributes: [{
-        quantity,
-        name: measure,
-      }],
-      otherMeasures: {
-        data: [{
-          attributes: {
-            quantity,
-            name: measure,
-          },
-        }],
-      },
-      quantity,
-      measure,
-      providerName,
-    };
-    ingredient.attributes = attributes;
     const body = {
-      ingredient: ingredient.attributes,
+      ingredient: {
+        name,
+        sku: ingredient.attributes.sku,
+        price,
+        currency: ingredient.attributes.currency,
+        ingredientMeasuresAttributes: selectMeasuresToModify(),
+        providerName,
+      },
     };
     editIngredient({ body, id: ingredient.id })
-      .then(() => {
+      .then(() => getIngredient({ id: ingredient.id }))
+      .then((resp) => {
         const auxIngredients = ingredients.filter(item => item.id !== ingredient.id);
-        auxIngredients.push(ingredient);
+        ingredient.attributes = resp.attributes;
+        auxIngredients.push(resp);
         setIngredients(auxIngredients);
         navigation.navigate('Ingrediente', {
           ingredient,
@@ -188,9 +198,8 @@ function FormIngredient({ navigation, route }) {
               onPress={() => navigation.navigate('Buscar Ingrediente', {
                 setName,
                 setPrice,
-                setQuantity,
                 setProviderName,
-                setMeasure,
+                setMeasure: (newMeasure) => handleMeasureChange(measures[0].id, newMeasure),
               })}
               style={styles.scrapperButton}>
               <Text style={styles.scrapperButtonText}>
@@ -257,47 +266,36 @@ function FormIngredient({ navigation, route }) {
               onChangeText={(text) => setPrice(text)}
             />
           </View>
-          <View style={styles.inputContainer}>
-            <Text style={styles.inputLabel}>
-              Cantidad
-            </Text>
-            <TextInput
-              style={styles.input}
-              placeholder="Cantidad de ingrediente..."
-              keyboardType="number-pad"
-              returnKeyType='done'
-              value={quantity.toString()}
-              onChangeText={(text) => setQuantity(text)}
+          <Text style={styles.measureLabel}>
+            Unidad por defecto
+          </Text>
+          <IngredientMeasureRow
+            key={measures[0].id}
+            measure={measures[0]}
+            handleMeasureChange={(newAttributes) => handleMeasureChange(measures[0].id, newAttributes)}
+            isDefault={true}
+            hasLabels={true}
+          />
+          <Text style={styles.measureLabel}>
+            Unidades alternativas
+          </Text>
+          {measures.filter((thisMeasure, index) => !thisMeasure.isRemoved && index).map((thisMeasure, index) => (
+            <IngredientMeasureRow
+              key={thisMeasure.id}
+              measure={thisMeasure}
+              handleMeasureChange={(newAttributes) => handleMeasureChange(thisMeasure.id, newAttributes)}
+              isDefault={false}
+              hasLabels={!index}
             />
-          </View>
-          <View style={styles.inputContainer}>
-            <Text style={styles.inputLabel}>
-              Unidad
-            </Text>
-            <View style={styles.dropDown}>
-              <RNPickerSelect
-                style={pickers.customPickerStyles}
-                key={'0'}
-                placeholder={{
-                  label: 'Selecciona unidad...',
-                  value: '',
-                }}
-                value={measure}
-                onValueChange={(value) => setMeasure(value)}
-                items={[
-                  { label: 'Kg', value: 'Kg', key: '0' },
-                  { label: 'Gr', value: 'Gr', key: '1' },
-                  { label: 'L', value: 'L', key: '2' },
-                  { label: 'Ml', value: 'Ml', key: '3' },
-                ]}
-              />
-
-            </View>
-            <Icon name='chevron-down'
-              size={30}
-              color={colors.kitchengramGray600}
-              style={styles.arrowIcon}
-            />
+          ))}
+          <View style={styles.buttonContainer}>
+            <TouchableOpacity
+              style={[styles.button, styles.addUnit]}
+              onPress={addNewMeasure}>
+              <Text style={[styles.buttonText, styles.confirmText]}>
+                Agregar Unidad
+              </Text>
+            </TouchableOpacity>
           </View>
 
         </View>

--- a/screens/Ingredients/SearchIngredientScreen.js
+++ b/screens/Ingredients/SearchIngredientScreen.js
@@ -18,7 +18,6 @@ function SearchIngredient({ navigation, route }) {
   const {
     setName,
     setPrice,
-    setQuantity,
     setProviderName,
     setMeasure,
   } = route.params;
@@ -95,9 +94,8 @@ function SearchIngredient({ navigation, route }) {
                 onPress={() => {
                   setName(product.name);
                   setPrice(product.price);
-                  setQuantity(1);
                   setProviderName(searchResponse[actualProvider].provider.name);
-                  setMeasure(product.measure);
+                  setMeasure({ name: product.measure, quantity: 1 });
                   navigation.navigate('Nuevo Ingrediente', {
                     isFromSearch: true,
                   });

--- a/screens/Ingredients/ShowIngredientScreen.js
+++ b/screens/Ingredients/ShowIngredientScreen.js
@@ -61,9 +61,7 @@ function ShowIngredient({ navigation, route }) {
           Cantidad
         </Text>
         <Text style={styles.value}>
-          {ingredient.attributes.otherMeasures.data[
-            ingredient.attributes.otherMeasures.data.length - 1
-          ].attributes.quantity}
+          {ingredient.attributes.otherMeasures.data[0].attributes.quantity}
         </Text>
       </View>
       <View style={styles.attributeContainer}>
@@ -71,7 +69,7 @@ function ShowIngredient({ navigation, route }) {
           Unidad
         </Text>
         <Text style={styles.value}>
-          {ingredient.attributes.measure}
+          {ingredient.attributes.otherMeasures.data[0].attributes.name}
         </Text>
       </View>
       <View style={styles.attributeContainer}>
@@ -80,9 +78,7 @@ function ShowIngredient({ navigation, route }) {
         </Text>
         <Text style={styles.value}>
           {`${formatMoney(
-            ingredient.attributes.price / ingredient.attributes.otherMeasures.data[
-              ingredient.attributes.otherMeasures.data.length - 1
-            ].attributes.quantity, '$')
+            ingredient.attributes.price / ingredient.attributes.otherMeasures.data[0].attributes.quantity, '$')
           } / ${ingredient.attributes.measure}`}
         </Text>
       </View>

--- a/store/store.js
+++ b/store/store.js
@@ -144,6 +144,18 @@ const storeThunks = {
 
     return ingredients;
   }),
+  getIngredient: thunk(async (actions, payload) => {
+    actions.setShowLoadingSpinner();
+    const ingredient = await ingredientsApi.getIngredient(payload)
+      .then((res) => res.data.data)
+      .catch((err) => {
+        actions.setIngredientsError(err.response.data.message);
+        throw err;
+      });
+    actions.setShowLoadingSpinner();
+
+    return ingredient;
+  }),
   createIngredient: thunk(async (actions, payload) => {
     actions.setShowLoadingSpinner();
     const ingredient = await ingredientsApi.createIngredient(payload)

--- a/styles/Ingredients/formStyles.js
+++ b/styles/Ingredients/formStyles.js
@@ -9,6 +9,13 @@ const styles = StyleSheet.create({
     paddingTop: 15,
   },
 
+  rowContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+  },
+
   inputContainer: {
     width: '100%',
     height: 60,
@@ -17,6 +24,35 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     marginVertical: 15,
     backgroundColor: colors.kitchengramWhite,
+  },
+
+  inputUnitContainer: {
+    width: '40%',
+    marginRight: '5%',
+    height: 60,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    marginVertical: 5,
+    backgroundColor: colors.kitchengramWhite,
+  },
+
+  inputNewMeasureContainer: {
+    width: '86%',
+    height: 60,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    marginVertical: 10,
+    backgroundColor: colors.kitchengramWhite,
+    marginRight: '5%',
+  },
+
+  measureLabel: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    fontStyle: 'normal',
+    color: colors.kitchengramBlack,
+    marginVertical: 15,
   },
 
   inputLabel: {
@@ -78,6 +114,18 @@ const styles = StyleSheet.create({
     height: '100%',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+
+  buttonContainer: {
+    width: '99%',
+    height: 65,
+    paddingVertical: 10,
+  },
+
+  addUnit: {
+    width: '48%',
+    backgroundColor: colors.kitchengramYellow500,
+    borderRadius: 5,
   },
 
   scrapperButton: {

--- a/styles/customPickerStyles.js
+++ b/styles/customPickerStyles.js
@@ -39,6 +39,9 @@ const pickers = {
       top: 20,
       right: 15,
     },
+    iconContainer: {
+      top: 5,
+    },
   },
   providerPicker: {
     inputIOS: {


### PR DESCRIPTION
**Qué se hizo**

* Se agregó la opción de agregar medidas equivalentes a los ingredientes
* Se dejaron medidas por defecto y la opción de agregar otra

**QA**
1. Crear o editar un ingrediente
2. Seleccionar medida por defecto y equivalentes, seleccionar una estándar de la lista o seleccionar ```otra```, escribir el nombre de la medida y apretar ✅ para crearla

![WhatsApp Image 2021-06-29 at 17 01 14](https://user-images.githubusercontent.com/42159846/123867064-e082ee00-d8fb-11eb-8a7c-b2e9e174e9ef.jpeg)
![WhatsApp Image 2021-06-29 at 17 01 13](https://user-images.githubusercontent.com/42159846/123867075-e2e54800-d8fb-11eb-8305-379588fe5cc7.jpeg)
![WhatsApp Image 2021-06-29 at 17 01 14-2](https://user-images.githubusercontent.com/42159846/123867087-e5e03880-d8fb-11eb-9cbb-73af99f536fc.jpeg)
