### PR TITLE
Reduce inventory from menus

### DIFF
--- a/api/menus.js
+++ b/api/menus.js
@@ -47,6 +47,14 @@ const menusApi = {
       data: payload.body,
     });
   },
+  reduceInventory: (payload) => {
+    const url = `${config.endpoints.menus.specific}${payload.id}/reduce-inventory`;
+
+    return apiUtils.api({
+      method: 'post',
+      url,
+    });
+  },
 };
 
 export default menusApi;

--- a/screens/Ingredients/IndexIngredientScreen.js
+++ b/screens/Ingredients/IndexIngredientScreen.js
@@ -14,7 +14,10 @@ import {
   RefreshControl,
 } from 'react-native';
 
-import { useStoreActions } from 'easy-peasy';
+import {
+  useStoreActions,
+  useStoreState,
+} from 'easy-peasy';
 import Icon from 'react-native-vector-icons/Ionicons';
 import styles from '../../styles/Ingredients/indexStyles';
 import colors from '../../styles/appColors';
@@ -23,22 +26,24 @@ import formatMoney from '../../utils/formatMoney';
 function IndexIngredients({ navigation }) {
   const getIngredients = useStoreActions((actions) => actions.getIngredients);
   const updateInventory = useStoreActions((actions) => actions.updateInventory);
+  const setIngredientsInventory = useStoreActions((actions) => actions.setIngredientsInventory);
+  const ingredientsInventory = useStoreState((state) => state.ingredientsInventory);
+
   const [ingredients, setIngredients] = useState([]);
   const evenNumber = 2;
   const [mounted, setMounted] = useState(false);
   const [editableInventories, setEditableInventories] = useState({});
   const [refreshing, setRefreshing] = useState(false);
-  const [newInventories, setNewInventories] = useState({});
 
   function inventoryModifier(event, ingId) {
-    const newInventoriesAux = { ...newInventories };
+    const newInventoriesAux = { ...ingredientsInventory };
     newInventoriesAux[ingId.toString()] = event;
 
-    setNewInventories(newInventoriesAux);
+    setIngredientsInventory(newInventoriesAux);
   }
 
   function submitInventoryValue(ingredient) {
-    const newInventory = Number(newInventories[ingredient.id.toString()]);
+    const newInventory = Number(ingredientsInventory[ingredient.id.toString()]);
     const ingredientsPayload = [{ ingredientId: ingredient.id, inventory: newInventory }];
     updateInventory({ ingredients: ingredientsPayload })
       .then(() => {
@@ -56,7 +61,7 @@ function IndexIngredients({ navigation }) {
     copyEditables[ingredient.id.toString()] = !copyEditables[ingredient.id.toString()];
 
     if (!copyEditables[ingredient.id.toString()] &&
-    ingredient.attributes.inventory !== newInventories[ingredient.id.toString()]) {
+    ingredient.attributes.inventory !== ingredientsInventory[ingredient.id.toString()]) {
       submitInventoryValue(ingredient);
     }
     setEditableInventories(copyEditables);
@@ -83,10 +88,11 @@ function IndexIngredients({ navigation }) {
         newInventoriesAux[ingredient.id.toString()] = ingredient.attributes.inventory;
         editableInventoriesAux[ingredient.id.toString()] = false;
       });
-      setNewInventories(newInventoriesAux);
+      setIngredientsInventory(newInventoriesAux);
       setEditableInventories(editableInventoriesAux);
       setMounted(true);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ingredients]);
 
   useLayoutEffect(() => {
@@ -111,6 +117,8 @@ function IndexIngredients({ navigation }) {
     getIngredients()
       .then((res) => {
         setIngredients(res);
+      })
+      .catch(() => {
       });
     setRefreshing(false);
   }
@@ -160,7 +168,7 @@ function IndexIngredients({ navigation }) {
                       <TouchableOpacity
                         style={styles.decreaseInventoryBtn}
                         onPress={() => inventoryModifier(
-                          newInventories[ingredient.id.toString()] - 1, ingredient.id)}
+                          ingredientsInventory[ingredient.id.toString()] - 1, ingredient.id)}
                       >
                         <Icon
                           name='remove-circle-outline'
@@ -172,14 +180,14 @@ function IndexIngredients({ navigation }) {
                         style={styles.inventoryInput}
                         keyboardType="number-pad"
                         returnKeyType='done'
-                        value={newInventories[ingredient.id.toString()].toString()}
+                        value={ingredientsInventory[ingredient.id.toString()].toString()}
                         onChangeText={(event) => inventoryModifier(event, ingredient.id)}
                         editable={true}
                       />
                       <TouchableOpacity
                         style={styles.increaseInventoryBtn}
                         onPress={() => inventoryModifier(
-                          newInventories[ingredient.id.toString()] + 1, ingredient.id)}
+                          ingredientsInventory[ingredient.id.toString()] + 1, ingredient.id)}
                       >
                         <Icon
                           name='add-circle-outline'
@@ -192,7 +200,7 @@ function IndexIngredients({ navigation }) {
                     <Text
                       style={styles.measure}
                     >
-                      {`${newInventories[ingredient.id.toString()]} un.`}
+                      {`${ingredientsInventory[ingredient.id.toString()]} un.`}
                     </Text>
                   )}
                   <TouchableOpacity onPress={() => showInventoryInput(ingredient)}>

--- a/screens/Menus/FormMenuScreen.js
+++ b/screens/Menus/FormMenuScreen.js
@@ -28,15 +28,15 @@ function MenuForm({ navigation, route }) {
   useEffect(() => {
     if (menu) {
       setSelectedRecipes(
-        menu.attributes.menu_recipes.data.map((menuRecipe) => ({
+        menu.attributes.menuRecipes.data.map((menuRecipe) => ({
           id: menuRecipe.attributes.recipe.id,
           menuRecipeId: Number(menuRecipe.id),
           name: menuRecipe.attributes.recipe.name,
           price: calculateRecipePrice({ attributes: menuRecipe.attributes.recipe }),
           selected: true,
-          quantity: menuRecipe.attributes.recipe_quantity,
-          quantityText: menuRecipe.attributes.recipe_quantity.toString(),
-          initialQuantity: menuRecipe.attributes.recipe_quantity,
+          quantity: menuRecipe.attributes.recipeQuantity,
+          quantityText: menuRecipe.attributes.recipeQuantity.toString(),
+          initialQuantity: menuRecipe.attributes.recipeQuantity,
           isNew: false,
         })),
       );

--- a/screens/Menus/MenuScreen.js
+++ b/screens/Menus/MenuScreen.js
@@ -34,7 +34,7 @@ function Menu(props) {
   const deleteMenu = useStoreActions((actions) => actions.deleteMenu);
   const setGlobalMenus = useStoreActions((actions) => actions.setMenus);
   const setIngredientsInventory = useStoreActions((actions) => actions.setIngredientsInventory);
-  const updateInventory = useStoreActions((actions) => actions.updateInventory);
+  const reduceInventory = useStoreActions((actions) => actions.reduceInventory);
   const ingredientsInventory = useStoreState((state) => state.ingredientsInventory);
 
   const {
@@ -52,20 +52,17 @@ function Menu(props) {
   useEffect(() => {
     if (confirmReduceInventory) {
       const ingredientsInventoryCopy = { ...ingredientsInventory };
-      const payload = [];
       Object.keys(newIngredientsInventory).forEach((id) => {
-        payload.push({
-          ingredientId: id,
-          inventory: newIngredientsInventory[id] < 0 ? 0 : newIngredientsInventory[id],
-        });
         ingredientsInventoryCopy[id] = newIngredientsInventory[id] < 0 ? 0 : newIngredientsInventory[id];
       });
-      updateInventory({ ingredients: payload })
+      reduceInventory({ id: menu.id })
         .then(() => {
           setIngredientsInventory(ingredientsInventoryCopy);
           setReduceInventorySuccessful(true);
         })
-        .catch(() => {
+        .catch((err) => {
+          console.log(err);
+          console.log(err.response.data);
         });
     }
     setConfirmReduceInventory(false);
@@ -88,7 +85,7 @@ function Menu(props) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  function reduceInventory() {
+  function reduceInventorySubmit() {
     const newIngredientsInventoryCopy = {};
     const alertIngredientsCopy = {};
     menu.attributes.menuRecipes.data.forEach((recipe) => {
@@ -187,7 +184,7 @@ function Menu(props) {
       <ScrollView>
         <TouchableOpacity
           style={styles.inventoryButton}
-          onPress={reduceInventory}
+          onPress={reduceInventorySubmit}
         >
           <Text style={styles.inventoryButtonText}>
             Reducir Inventario

--- a/screens/Menus/MenuScreen.js
+++ b/screens/Menus/MenuScreen.js
@@ -136,7 +136,7 @@ function Menu(props) {
         transparent={true}
       >
         <View style={styles.centeredView}>
-          <View style={styles.modalView}>
+          <View style={[styles.modalView, styles.modalViewSuccesful]}>
             <Text style={styles.modalTitle}>
               Reducción de inventario exitosa
             </Text>

--- a/store/store.js
+++ b/store/store.js
@@ -29,6 +29,7 @@ const storeState = {
   providersError: '',
   chargeProviders: false,
   showLoadingSpinner: false,
+  ingredientsInventory: {},
 };
 
 const getters = {
@@ -104,6 +105,9 @@ const storeActions = {
   }),
   setShowLoadingSpinner: action((state) => {
     state.showLoadingSpinner = !state.showLoadingSpinner;
+  }),
+  setIngredientsInventory: action((state, payload) => {
+    state.ingredientsInventory = payload;
   }),
 };
 

--- a/store/store.js
+++ b/store/store.js
@@ -219,6 +219,7 @@ const storeThunks = {
     return recipes;
   }),
   createRecipe: thunk(async (actions, payload) => {
+    actions.setShowLoadingSpinner();
     const recipe = await recipesApi.createRecipe(payload)
       .then((resp) => resp.data.data)
       .catch((err) => {

--- a/store/store.js
+++ b/store/store.js
@@ -80,7 +80,7 @@ const storeActions = {
   setDeletedRecipe: action((state, payload) => {
     state.recipes.delete = payload;
   }),
-  setmenusError: action((state, payload) => {
+  setMenusError: action((state, payload) => {
     state.menusError = payload;
   }),
   setMenus: action((state, payload) => {
@@ -352,6 +352,15 @@ const storeThunks = {
     actions.setShowLoadingSpinner();
 
     return menu;
+  }),
+  reduceInventory: thunk(async (actions, payload) => {
+    actions.setShowLoadingSpinner();
+    await menusApi.reduceInventory(payload)
+      .catch((err) => {
+        actions.setMenusError(err.response.data.message);
+        throw err;
+      });
+    actions.setShowLoadingSpinner();
   }),
   getProviders: thunk(async (actions, payload) => {
     actions.setShowLoadingSpinner();

--- a/styles/Menus/showStyles.js
+++ b/styles/Menus/showStyles.js
@@ -123,10 +123,14 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
+  modalViewSuccesful: {
+    minHeight: '20%',
+    minWidth: '60%',
+  },
   modalView: {
-    minHeight: '22%',
+    minHeight: '35%',
     maxHeight: '50%',
-    minWidth: '80%',
+    minWidth: '90%',
     margin: 20,
     backgroundColor: 'white',
     borderRadius: 20,

--- a/styles/Menus/showStyles.js
+++ b/styles/Menus/showStyles.js
@@ -149,18 +149,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  button: {
-    borderRadius: 5,
-    padding: 10,
-    marginTop: 10,
-    elevation: 2,
-    backgroundColor: colors.kitchengramGreen500,
-  },
-  textStyle: {
-    color: 'white',
-    fontWeight: 'bold',
-    textAlign: 'center',
-  },
   modalText: {
     width: '100%',
     fontSize: 14,
@@ -175,6 +163,42 @@ const styles = StyleSheet.create({
     color: colors.black,
     textAlign: 'center',
     marginBottom: 10,
+  },
+  modalButtonsContainer: {
+    width: '100%',
+    height: 30,
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  cancelButton: {
+    width: '48%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderRadius: 5,
+    borderColor: colors.kitchengramGray600,
+  },
+  confirmButton: {
+    width: '48%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.kitchengramGreen500,
+    borderRadius: 5,
+  },
+  buttonText: {
+    fontWeight: 'normal',
+    fontStyle: 'normal',
+    fontSize: 16,
+  },
+  cancelButtonText: {
+    color: colors.kitchengramGray600,
+  },
+  confirmButtonText: {
+    color: colors.kitchengramWhite,
   },
 });
 

--- a/styles/Menus/showStyles.js
+++ b/styles/Menus/showStyles.js
@@ -5,7 +5,6 @@ const styles = StyleSheet.create({
   container: {
     backgroundColor: colors.white,
     flex: 1,
-    paddingTop: 15,
   },
 
   infoContainer: {
@@ -94,6 +93,84 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: colors.selectedTabYellow,
     textAlign: 'right',
+  },
+
+  moreVert: {
+    paddingRight: 8,
+  },
+
+  inventoryButton: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 9,
+    width: '90%',
+    borderWidth: 1,
+    marginLeft: '5%',
+    marginTop: 10,
+    marginBottom: 10,
+    borderRadius: 5,
+    color: colors.kitchengramGray600,
+    borderColor: colors.kitchengramGray600,
+  },
+
+  inventoryButtonText: {
+    fontSize: 16,
+  },
+
+  centeredView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalView: {
+    minHeight: '22%',
+    maxHeight: '50%',
+    minWidth: '80%',
+    margin: 20,
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 20,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: {
+    borderRadius: 5,
+    padding: 10,
+    marginTop: 10,
+    elevation: 2,
+    backgroundColor: colors.kitchengramGreen500,
+  },
+  textStyle: {
+    color: 'white',
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  modalText: {
+    width: '100%',
+    fontSize: 14,
+    color: colors.black,
+    textAlign: 'center',
+    marginVertical: 3,
+  },
+  modalTitle: {
+    width: '100%',
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: colors.black,
+    textAlign: 'center',
+    marginBottom: 10,
   },
 });
 


### PR DESCRIPTION
# Contexto
Se da la opción de reducir inventario desde un menú específico, es decir, desde el show.
Puntos a considerar,

1. Lista conexión con backend, se le envía un Array con los los ids y nuevos valores de inventario de cada ingrediente modificado (`[{ id: newInventoryValue }]`.
2. Manejo local para mostrar cambios de inventario en la aplicación mobile:
  - Para esto se cambio el manejo de inventarios de un state de la vista de index a un state en el store.
  - Variable `ingredientsInventory` es un objeto de la forma `{ ingredientId: ingredientInventory }`.
  - Una vez que se realiza el llamado a backend para actualizar inventarios (a través de `updateInventory`) se actualizan los valores del estado `ingredientsInventory`.
3. Cuando se quiere reducir inventario de un menú, y falta cierta cantidad de un ingrediente antes de hacer el llamado se le avisa al usuario que ingrediente le falta y la cantidad faltante, después los valores de inventarios de estos ingredientes quedan en 0.

![WhatsApp Image 2021-07-04 at 12 22 41](https://user-images.githubusercontent.com/48318555/124392460-b6e31180-dcc3-11eb-9cb1-67551a893b2f.jpeg)


#QA
1. Ir a lista de menús y abrir uno
2. Debería aparecer un botón de reducir inventario.
3. Apretar botón
  - Si es que no hay problemas de inventario (existe una cantidad necesaria para cada ingrediente) se hará la reducción en cada ingrediente perteneciente al menú (localmente y en backend)
  - Si es que hay problemas de inventario con algún ingrediente aparecerá una lista con cada nombre y cantidad faltante los ingredientes.
4. Ir al index de ingredientes y verificar que efectivamente se disminuyó el inventario.