### PR TITLE
feat(refreshControl): fix refresh control not working when index wher…

### DIFF
--- a/screens/Ingredients/IndexIngredientScreen.js
+++ b/screens/Ingredients/IndexIngredientScreen.js
@@ -244,9 +244,17 @@ function IndexIngredients({ navigation }) {
   }
 
   return (mounted &&
-    <Text style={styles.emptyMessage}>
-      Aún no tienes ingredientes.
-    </Text>
+    <ScrollView
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+        />
+      }>
+      <Text style={styles.emptyMessage}>
+        Aún no tienes ingredientes.
+      </Text>
+    </ScrollView>
   );
 }
 

--- a/screens/Menus/MenusScreen.js
+++ b/screens/Menus/MenusScreen.js
@@ -43,7 +43,7 @@ function Menus({ navigation }) {
       ),
       headerTitle: 'Menus',
     });
-  }, [navigation, menus]);
+  }, [navigation, menus, globalMenus]);
 
   useEffect(() => {
     getMenus()
@@ -85,9 +85,16 @@ function Menus({ navigation }) {
   }
 
   return (mounted) && (
-    <Text style={styles.emptyMessage}>
-      Aún no tienes menús.
-    </Text>
+    <ScrollView style={styles.scroll} refreshControl={
+      <RefreshControl
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+      />
+    }>
+      <Text style={styles.emptyMessage}>
+        Aún no tienes menús.
+      </Text>
+    </ScrollView>
   );
 }
 

--- a/screens/Providers/IndexProviderScreen.js
+++ b/screens/Providers/IndexProviderScreen.js
@@ -107,9 +107,16 @@ function IndexProviders({ navigation }) {
   }
 
   return (mounted) && (
-    <Text style={styles.emptyMessage}>
-      Aún no tienes proveedores.
-    </Text>
+    <ScrollView style={styles.scroll} refreshControl={
+      <RefreshControl
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+      />
+    }>
+      <Text style={styles.emptyMessage}>
+        Aún no tienes proveedores.
+      </Text>
+    </ScrollView>
   );
 }
 

--- a/screens/Recipes/RecipesScreen.js
+++ b/screens/Recipes/RecipesScreen.js
@@ -77,9 +77,16 @@ function Recipes(props) {
 
   if (mounted) {
     return (
-      <Text style={styles.emptyMessage}>
-        Aún no tienes recetas.
-      </Text>
+      <ScrollView style={styles.scroll} refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+        />
+      }>
+        <Text style={styles.emptyMessage}>
+          Aún no tienes recetas.
+        </Text>
+      </ScrollView>
     );
   }
 


### PR DESCRIPTION
## Que se hizo
- se arregló el problema de no poder actualizar deslizando para abajo cuando el index de cualquier crud se encontraba vacío
- para esto se añadió el Scrollview con RefreshControl para el caso en que no hubieran elementos en el index

## QA
- ingresar a la app en dos dispositivos distintos con una cuenta vacía (puede ser la página web tambiṕen para el sugundo dispositivo)
- crear un ingrediente en un dispositivo y en la vista con "aun no tienes ingredientes" del otro deslizar hacia abajo para ver si aparece el ingrediente creado
- replicar el procediemiento para recetas, menús y proveedores