### PR TITLE
Various fixes

### DIFF
--- a/screens/Ingredients/FormIngredientScreen.js
+++ b/screens/Ingredients/FormIngredientScreen.js
@@ -285,7 +285,7 @@ function FormIngredient({ navigation, route }) {
               placeholder="Minimo inventario ..."
               keyboardType="number-pad"
               returnKeyType='done'
-              value={minimumQuantity.toString()}
+              value={(minimumQuantity) && minimumQuantity.toString()}
               onChangeText={(text) => setMinimumQuantity(text)}
             />
           </View>

--- a/screens/Ingredients/FormIngredientScreen.js
+++ b/screens/Ingredients/FormIngredientScreen.js
@@ -43,7 +43,7 @@ function FormIngredient({ navigation, route }) {
   const createIngredient = useStoreActions((actions) => actions.createIngredient);
   const editIngredient = useStoreActions((actions) => actions.editIngredient);
   const getProviders = useStoreActions((actions) => actions.getProviders);
-  const setChargeProviders = useStoreActions((actions) => actions.setChargeProviders);
+  const setHasToGetProviders = useStoreActions((actions) => actions.setHasToGetProviders);
 
   const [name, setName] = useState(ingredient.attributes.name);
   const [price, setPrice] = useState(ingredient.attributes.price);
@@ -156,7 +156,7 @@ function FormIngredient({ navigation, route }) {
       .then((res) => {
         setIngredients([...ingredients, res]);
         if (isFromSearch) {
-          setChargeProviders();
+          setHasToGetProviders();
         }
         navigation.navigate('Ingredientes');
       })

--- a/screens/Ingredients/IndexIngredientScreen.js
+++ b/screens/Ingredients/IndexIngredientScreen.js
@@ -29,6 +29,7 @@ function IndexIngredients({ navigation }) {
   const updateInventory = useStoreActions((actions) => actions.updateInventory);
   const setIngredientsInventory = useStoreActions((actions) => actions.setIngredientsInventory);
   const ingredientsInventory = useStoreState((state) => state.ingredientsInventory);
+  const setChargeRecipes = useStoreActions((actions) => actions.setChargeRecipes);
 
   const [ingredients, setIngredients] = useState([]);
   const evenNumber = 2;
@@ -86,6 +87,11 @@ function IndexIngredients({ navigation }) {
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    setChargeRecipes();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ingredients]);
 
   useEffect(() => {
     if (ingredients.length > 0) {

--- a/screens/Ingredients/IndexIngredientScreen.js
+++ b/screens/Ingredients/IndexIngredientScreen.js
@@ -31,7 +31,7 @@ function IndexIngredients({ navigation }) {
   const updateInventory = useStoreActions((actions) => actions.updateInventory);
   const setIngredientsInventory = useStoreActions((actions) => actions.setIngredientsInventory);
   const ingredientsInventory = useStoreState((state) => state.ingredientsInventory);
-  const setChargeRecipes = useStoreActions((actions) => actions.setChargeRecipes);
+  const setHasToGetRecipes = useStoreActions((actions) => actions.setHasToGetRecipes);
   const [showModal, setShowModal] = useState(false);
 
   const [ingredients, setIngredients] = useState([]);
@@ -92,7 +92,7 @@ function IndexIngredients({ navigation }) {
   }, []);
 
   useEffect(() => {
-    setChargeRecipes();
+    setHasToGetRecipes();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ingredients]);
 

--- a/screens/Menus/MenuScreen.js
+++ b/screens/Menus/MenuScreen.js
@@ -104,14 +104,16 @@ function Menu(props) {
           newInventory = ingredientsInventory[id] - ingredient.attributes.ingredientQuantity;
         }
         newIngredientsInventoryCopy[id] = {
-          quantity: newInventory,
+          // eslint-disable-next-line no-magic-numbers
+          quantity: Math.round(newInventory * 100) / 100,
           measure: ingredient.attributes.ingredient.measure,
           name: ingredient.attributes.ingredient.name,
         };
         if (newInventory < 0) {
           alertIngredientsCopy[ingredient.attributes.ingredient.name] = {
             id,
-            quantity: Math.abs(newInventory),
+            // eslint-disable-next-line no-magic-numbers
+            quantity: Math.abs(Math.round(newInventory * 100) / 100),
             measure: ingredient.attributes.ingredient.measure,
           };
         }

--- a/screens/Menus/MenuScreen.js
+++ b/screens/Menus/MenuScreen.js
@@ -52,6 +52,7 @@ function Menu(props) {
   const [newIngredientsInventory, setNewIngredientsInventory] = useState({});
   const [confirmReduceInventory, setConfirmReduceInventory] = useState(false);
   const [confirmReduceInventoryModal, setConfirmReduceInventoryModal] = useState(false);
+  const [allIngredientsEmpty, setAllIngredientsEmpty] = useState(false);
   const [reduceInventorySuccessful, setReduceInventorySuccessful] = useState(false);
 
   useEffect(() => {
@@ -91,6 +92,7 @@ function Menu(props) {
   function reduceInventorySubmit() {
     const newIngredientsInventoryCopy = {};
     const alertIngredientsCopy = {};
+    let totalIngredients = 0;
     menu.attributes.menuRecipes.data.forEach((recipe) => {
       recipe.attributes.recipe.recipeIngredients.data.forEach((ingredient) => {
         const id = ingredient.attributes.ingredient.id.toString();
@@ -98,6 +100,7 @@ function Menu(props) {
         if (Object.keys(newIngredientsInventoryCopy).includes(id)) {
           newInventory = newIngredientsInventoryCopy[id] - ingredient.attributes.ingredientQuantity;
         } else {
+          totalIngredients += 1;
           newInventory = ingredientsInventory[id] - ingredient.attributes.ingredientQuantity;
         }
         newIngredientsInventoryCopy[id] = {
@@ -107,12 +110,16 @@ function Menu(props) {
         };
         if (newInventory < 0) {
           alertIngredientsCopy[ingredient.attributes.ingredient.name] = {
+            id,
             quantity: Math.abs(newInventory),
             measure: ingredient.attributes.ingredient.measure,
           };
         }
       });
     });
+    if (Object.keys(alertIngredientsCopy).length === totalIngredients) {
+      setAllIngredientsEmpty(true);
+    }
     setNewIngredientsInventory(newIngredientsInventoryCopy);
     setAlertIngredients(alertIngredientsCopy);
     setConfirmReduceInventoryModal(true);
@@ -181,32 +188,46 @@ function Menu(props) {
         <View style={styles.centeredView}>
           <View style={styles.modalView}>
             <Text style={styles.modalTitle}>
-              Ingredientes modificados
+              {(!allIngredientsEmpty) && 'Ingredientes a modificar'}
             </Text>
-            <ScrollView>
-              {Object.keys(newIngredientsInventory).map((key, i) =>
-                (!Object.keys(alertIngredients).includes(newIngredientsInventory[key].name)) && (
-                  <Text
-                    key={i.toString()}
-                    style={styles.modalText}
-                  >
-                    {newIngredientsInventory[key].name}: de {ingredientsInventory[key]} a{' '}
-                    {newIngredientsInventory[key].quantity} {newIngredientsInventory[key].measure}
-                  </Text>
-                ))}
-            </ScrollView>
+            {(!allIngredientsEmpty) && (
+              <ScrollView>
+                {Object.keys(newIngredientsInventory).map((key, i) =>
+                  (!Object.keys(alertIngredients).includes(newIngredientsInventory[key].name)) && (
+                    <View key={i.toString()}>
+                      <Text
+                        style={[styles.modalText, styles.bold]}
+                      >
+                        {`${newIngredientsInventory[key].name}:`}
+                      </Text>
+                      <Text style={styles.modalText}>
+                        {`Tienes ${ingredientsInventory[key]} - ` +
+                        `Quedarán ${newIngredientsInventory[key].quantity} ${newIngredientsInventory[key].measure}`}
+                      </Text>
+                    </View>
+                  ))}
+              </ScrollView>
+            )}
             <Text style={styles.modalTitle}>
               {Object.keys(alertIngredients).length > 0 && 'Ingredientes con falta de inventario'}
+            </Text>
+            <Text style={styles.modalSubtitle}>
+              {Object.keys(alertIngredients).length > 0 && 'Se reducirán quedando en 0'}
             </Text>
             {Object.keys(alertIngredients).length > 0 && (
               <ScrollView>
                 {Object.keys(alertIngredients).map((key, i) => (
-                  <Text
-                    key={i.toString()}
-                    style={styles.modalText}
-                  >
-                    {`${key}: ${alertIngredients[key].quantity} ${alertIngredients[key].measure}`}
-                  </Text>
+                  <View key={i.toString()}>
+                    <Text
+                      style={[styles.modalText, styles.bold]}
+                    >
+                      {`${key}:`}
+                    </Text>
+                    <Text style={styles.modalText}>
+                      {`Tienes ${ingredientsInventory[alertIngredients[key].id]} - ` +
+                      `Faltan ${alertIngredients[key].quantity} ${alertIngredients[key].measure}`}
+                    </Text>
+                  </View>
                 ))}
               </ScrollView>
             )}
@@ -293,12 +314,12 @@ function Menu(props) {
           <TouchableOpacity
             style={styles.shoppingListButton}
             onPress={() => exportShoppingList()}
-          ><Text style={styles.shoppingListText}>Exportar lista de compras</Text>
+          ><Text style={styles.shoppingListText}>Exportar</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.shoppingListButton}
             onPress={() => copyShoppingListToClipboard()}
-          ><Text style={styles.shoppingListText}>Copiar lista en el portapapeles</Text>
+          ><Text style={styles.shoppingListText}>Copiar</Text>
           </TouchableOpacity>
         </View>
       </ScrollView>

--- a/screens/Menus/MenuScreen.js
+++ b/screens/Menus/MenuScreen.js
@@ -119,6 +119,8 @@ function Menu(props) {
   }
 
   function copyShoppingListToClipboard() {
+    if (!(menu.attributes.menuRecipes.data > 0)) return;
+
     getShoppingList({ id: menu.id })
       .then((res) => {
         copyList(res);
@@ -127,6 +129,8 @@ function Menu(props) {
   }
 
   function exportShoppingList() {
+    if (!(menu.attributes.menuRecipes.data > 0)) return;
+
     getShoppingList({ id: menu.id })
       .then((res) => {
         createExcel(res);

--- a/screens/Menus/MenuScreen.js
+++ b/screens/Menus/MenuScreen.js
@@ -214,7 +214,7 @@ function Menu(props) {
               {Object.keys(alertIngredients).length > 0 && 'Ingredientes con falta de inventario'}
             </Text>
             <Text style={styles.modalSubtitle}>
-              {Object.keys(alertIngredients).length > 0 && 'Se reducirán quedando en 0'}
+              {Object.keys(alertIngredients).length > 0 && 'Quedarán con inventario 0'}
             </Text>
             {Object.keys(alertIngredients).length > 0 && (
               <ScrollView>

--- a/screens/Menus/MenusScreen.js
+++ b/screens/Menus/MenusScreen.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 import React, {
   useEffect,
   useState,
@@ -13,6 +14,8 @@ function Menus({ navigation }) {
   const getMenus = useStoreActions((actions) => actions.getMenus);
   const globalMenus = useStoreState((state) => state.menus.menus);
   const setGlobalMenus = useStoreActions((actions) => actions.setMenus);
+  const setChargeMenus = useStoreActions((actions) => actions.setChargeMenus);
+  const chargeMenus = useStoreState((state) => state.chargeMenus);
 
   const [mounted, setMounted] = useState(false);
   const [menus, setMenus] = useState([]);
@@ -55,6 +58,20 @@ function Menus({ navigation }) {
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (chargeMenus) {
+      getMenus()
+        .then((res) => {
+          setChargeMenus();
+          setGlobalMenus(res);
+          setMounted(true);
+        })
+        .catch(() => {
+        });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chargeMenus]);
 
   useEffect(() => {
     setMenus(globalMenus);

--- a/screens/Menus/MenusScreen.js
+++ b/screens/Menus/MenusScreen.js
@@ -14,8 +14,8 @@ function Menus({ navigation }) {
   const getMenus = useStoreActions((actions) => actions.getMenus);
   const globalMenus = useStoreState((state) => state.menus.menus);
   const setGlobalMenus = useStoreActions((actions) => actions.setMenus);
-  const setChargeMenus = useStoreActions((actions) => actions.setChargeMenus);
-  const chargeMenus = useStoreState((state) => state.chargeMenus);
+  const setHasToGetMenus = useStoreActions((actions) => actions.setHasToGetMenus);
+  const hasToGetMenus = useStoreState((state) => state.hasToGetMenus);
 
   const [mounted, setMounted] = useState(false);
   const [menus, setMenus] = useState([]);
@@ -60,10 +60,10 @@ function Menus({ navigation }) {
   }, []);
 
   useEffect(() => {
-    if (chargeMenus) {
+    if (hasToGetMenus) {
       getMenus()
         .then((res) => {
-          setChargeMenus();
+          setHasToGetMenus();
           setGlobalMenus(res);
           setMounted(true);
         })
@@ -71,7 +71,7 @@ function Menus({ navigation }) {
         });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chargeMenus]);
+  }, [hasToGetMenus]);
 
   useEffect(() => {
     setMenus(globalMenus);

--- a/screens/Providers/FormProviderScreen.js
+++ b/screens/Providers/FormProviderScreen.js
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   Text,
   TextInput,
+  Modal,
 } from 'react-native';
 import { useStoreActions } from 'easy-peasy';
 import styles from '../../styles/Providers/formStyles';
@@ -38,6 +39,7 @@ function FormProvider({ navigation, route }) {
     setProviders,
   } = route.params;
 
+  const [showModalError, setShowModalError] = useState(false);
   const [name, setName] = useState(provider.attributes.name);
   const [email, setEmail] = useState(provider.attributes.email ? provider.attributes.email : '');
   const [phone, setPhone] = useState(provider.attributes.phone);
@@ -100,7 +102,11 @@ function FormProvider({ navigation, route }) {
           setProviders(auxProviders);
           navigation.navigate('Proveedores');
         })
-        .catch(() => {
+        .catch((err) => {
+          // eslint-disable-next-line no-magic-numbers
+          if (err.response.status === 400) {
+            setShowModalError(true);
+          }
         });
     } else {
       editProvider({ body, id: provider.id })
@@ -114,7 +120,11 @@ function FormProvider({ navigation, route }) {
             setProviders,
           });
         })
-        .catch(() => {
+        .catch((err) => {
+          // eslint-disable-next-line no-magic-numbers
+          if (err.response.status === 400) {
+            setShowModalError(true);
+          }
         });
     }
   }
@@ -123,6 +133,28 @@ function FormProvider({ navigation, route }) {
     <>
       <KeyboardAvoidWrapper>
         <View style={styles.container}>
+          <Modal
+            visible={showModalError}
+            transparent={true}
+          >
+            <View style={styles.centeredView}>
+              <View style={styles.modalView}>
+                <Text style={styles.modalTitle}>
+                  Ya existe un proveedor con este nombre
+                </Text>
+                <View style={styles.modalButtonContainer}>
+                  <TouchableOpacity
+                    style={styles.confirmButton}
+                    onPress={() => setShowModalError(false)}
+                  >
+                    <Text style={styles.confirmButtonText}>
+                      Aceptar
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            </View>
+          </Modal>
           <View style={styles.inputContainer}>
             <Text style={styles.inputLabel}>
               Nombre
@@ -282,7 +314,6 @@ function FormProvider({ navigation, route }) {
           </Text>
         </TouchableOpacity>
       </View>
-
     </>
   );
 }

--- a/screens/Providers/FormProviderScreen.js
+++ b/screens/Providers/FormProviderScreen.js
@@ -56,6 +56,8 @@ function FormProvider({ navigation, route }) {
   const createProvider = useStoreActions((actions) => actions.createProvider);
   const editProvider = useStoreActions((actions) => actions.editProvider);
 
+  const BAD_REQUEST = 400;
+
   function checkValidInputs() {
     const validations = [
       { error: !name.length, message: 'Debes asignar un nombre al proveedor' },
@@ -103,8 +105,7 @@ function FormProvider({ navigation, route }) {
           navigation.navigate('Proveedores');
         })
         .catch((err) => {
-          // eslint-disable-next-line no-magic-numbers
-          if (err.response.status === 400) {
+          if (err.response.status === BAD_REQUEST) {
             setShowModalError(true);
           }
         });
@@ -121,8 +122,7 @@ function FormProvider({ navigation, route }) {
           });
         })
         .catch((err) => {
-          // eslint-disable-next-line no-magic-numbers
-          if (err.response.status === 400) {
+          if (err.response.status === BAD_REQUEST) {
             setShowModalError(true);
           }
         });

--- a/screens/Providers/IndexProviderScreen.js
+++ b/screens/Providers/IndexProviderScreen.js
@@ -20,8 +20,8 @@ import colors from '../../styles/appColors';
 
 function IndexProviders({ navigation }) {
   const getProviders = useStoreActions((actions) => actions.getProviders);
-  const chargeProviders = useStoreState((state) => state.chargeProviders);
-  const setChargeProviders = useStoreActions((actions) => actions.setChargeProviders);
+  const hasToGetProviders = useStoreState((state) => state.hasToGetProviders);
+  const setHasToGetProviders = useStoreActions((actions) => actions.setHasToGetProviders);
   const [mounted, setMounted] = useState(false);
   const [providers, setProviders] = useState([]);
   const [refreshing, setRefreshing] = useState(false);
@@ -64,10 +64,10 @@ function IndexProviders({ navigation }) {
   }, [getProviders]);
 
   useEffect(() => {
-    if (chargeProviders) {
+    if (hasToGetProviders) {
       getProviders()
         .then((res) => {
-          setChargeProviders();
+          setHasToGetProviders();
           setProviders(res);
           setMounted(true);
         })
@@ -75,7 +75,7 @@ function IndexProviders({ navigation }) {
         });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chargeProviders]);
+  }, [hasToGetProviders]);
 
   if (providers.length) {
     return (

--- a/screens/Providers/IndexProviderScreen.js
+++ b/screens/Providers/IndexProviderScreen.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 import React, {
   useEffect,
   useState,
@@ -9,13 +10,18 @@ import {
   ScrollView,
   RefreshControl,
 } from 'react-native';
-import { useStoreActions } from 'easy-peasy';
+import {
+  useStoreActions,
+  useStoreState,
+} from 'easy-peasy';
 import Icon from 'react-native-vector-icons/Ionicons';
 import styles from '../../styles/Providers/indexStyles';
 import colors from '../../styles/appColors';
 
 function IndexProviders({ navigation }) {
   const getProviders = useStoreActions((actions) => actions.getProviders);
+  const chargeProviders = useStoreState((state) => state.chargeProviders);
+  const setChargeProviders = useStoreActions((actions) => actions.setChargeProviders);
   const [mounted, setMounted] = useState(false);
   const [providers, setProviders] = useState([]);
   const [refreshing, setRefreshing] = useState(false);
@@ -56,6 +62,21 @@ function IndexProviders({ navigation }) {
       .catch(() => {
       });
   }, [getProviders]);
+
+  useEffect(() => {
+    if (chargeProviders) {
+      getProviders()
+        .then((res) => {
+          setChargeProviders();
+          setProviders(res);
+          setMounted(true);
+        })
+        .catch(() => {
+        });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chargeProviders]);
+
   if (providers.length) {
     return (
       <View style={styles.container}>

--- a/screens/Providers/ShowProviderScreen.js
+++ b/screens/Providers/ShowProviderScreen.js
@@ -77,7 +77,9 @@ function ShowProvider({ navigation, route }) {
           </Text>
           <Text
             style={styles.linkValue}
-            onPress={() => Linking.openURL(`https://${provider.attributes.webpageUrl}`)}
+            onPress={(provider.attributes.webpageUrl) ?
+              () => Linking.openURL(`https://${provider.attributes.webpageUrl}`) :
+              null}
           >
             {provider.attributes.webpageUrl}
           </Text>

--- a/screens/Recipes/RecipeStepsScreen.js
+++ b/screens/Recipes/RecipeStepsScreen.js
@@ -122,8 +122,13 @@ function NewStep(props) {
         returnKeyType='done'
       />
       <View style={styles.sectionNewStep}>
-        <TouchableOpacity style={styles.stepButton} onPress={addStep}>
-          <Text style={styles.ingredientButtonText}>Agregar paso</Text>
+        <TouchableOpacity
+          style={styles.stepButton}
+          onPress={(newStepDescription) ? addStep : null}
+        >
+          <Text style={styles.ingredientButtonText}>
+            Agregar paso
+          </Text>
         </TouchableOpacity>
       </View>
     </>

--- a/screens/Recipes/RecipesScreen.js
+++ b/screens/Recipes/RecipesScreen.js
@@ -14,7 +14,7 @@ function Recipes(props) {
   const getRecipes = useStoreActions((actions) => actions.getRecipes);
   const setChargeMenus = useStoreActions((actions) => actions.setChargeMenus);
   const setChargeRecipes = useStoreActions((actions) => actions.setChargeRecipes);
-  const chargeRecipes = useStoreState((state) => state.setChargeMenus);
+  const chargeRecipes = useStoreState((state) => state.chargeRecipes);
   const [recipes, setRecipes] = useState([]);
   const [, setShowError] = useState(false);
   const [, setErrorMessage] = useState('');

--- a/screens/Recipes/RecipesScreen.js
+++ b/screens/Recipes/RecipesScreen.js
@@ -12,9 +12,9 @@ import styles from '../../styles/Recipes/indexStyles';
 function Recipes(props) {
   const { navigation } = props;
   const getRecipes = useStoreActions((actions) => actions.getRecipes);
-  const setChargeMenus = useStoreActions((actions) => actions.setChargeMenus);
-  const setChargeRecipes = useStoreActions((actions) => actions.setChargeRecipes);
-  const chargeRecipes = useStoreState((state) => state.chargeRecipes);
+  const setHasToGetMenus = useStoreActions((actions) => actions.setHasToGetMenus);
+  const setHasToGetRecipes = useStoreActions((actions) => actions.setHasToGetRecipes);
+  const hasToGetRecipes = useStoreState((state) => state.hasToGetRecipes);
   const [recipes, setRecipes] = useState([]);
   const [, setShowError] = useState(false);
   const [, setErrorMessage] = useState('');
@@ -46,15 +46,15 @@ function Recipes(props) {
   }, []);
 
   useEffect(() => {
-    setChargeMenus();
+    setHasToGetMenus();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recipes]);
 
   useEffect(() => {
-    if (chargeRecipes) {
+    if (hasToGetRecipes) {
       getRecipes()
         .then((res) => {
-          setChargeRecipes();
+          setHasToGetRecipes();
           setRecipes(res);
         })
         .catch((err) => {
@@ -66,7 +66,7 @@ function Recipes(props) {
         });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chargeRecipes]);
+  }, [hasToGetRecipes]);
 
   useLayoutEffect(() => {
     navigation.setOptions({

--- a/screens/Recipes/RecipesScreen.js
+++ b/screens/Recipes/RecipesScreen.js
@@ -1,7 +1,10 @@
 /* eslint-disable max-statements */
 import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { Text, ScrollView, RefreshControl } from 'react-native';
-import { useStoreActions } from 'easy-peasy';
+import {
+  useStoreActions,
+  useStoreState,
+} from 'easy-peasy';
 import Icon from 'react-native-vector-icons/Ionicons';
 import RecipeRow from '../../components/recipeRow';
 import styles from '../../styles/Recipes/indexStyles';
@@ -9,6 +12,9 @@ import styles from '../../styles/Recipes/indexStyles';
 function Recipes(props) {
   const { navigation } = props;
   const getRecipes = useStoreActions((actions) => actions.getRecipes);
+  const setChargeMenus = useStoreActions((actions) => actions.setChargeMenus);
+  const setChargeRecipes = useStoreActions((actions) => actions.setChargeRecipes);
+  const chargeRecipes = useStoreState((state) => state.setChargeMenus);
   const [recipes, setRecipes] = useState([]);
   const [, setShowError] = useState(false);
   const [, setErrorMessage] = useState('');
@@ -38,6 +44,29 @@ function Recipes(props) {
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    setChargeMenus();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recipes]);
+
+  useEffect(() => {
+    if (chargeRecipes) {
+      getRecipes()
+        .then((res) => {
+          setChargeRecipes();
+          setRecipes(res);
+        })
+        .catch((err) => {
+          setShowError(true);
+          setErrorMessage(err);
+        })
+        .finally(() => {
+          setMounted(true);
+        });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chargeRecipes]);
 
   useLayoutEffect(() => {
     navigation.setOptions({

--- a/store/store.js
+++ b/store/store.js
@@ -422,7 +422,12 @@ const storeThunks = {
   createProvider: thunk(async (actions, payload) => {
     actions.setShowLoadingSpinner();
     const provider = await providersApi.createProvider(payload)
-      .then((res) => res.data.data);
+      .then((res) => res.data.data)
+      .catch((err) => {
+        actions.setProvidersError(err.response.data.message);
+        actions.setShowLoadingSpinner();
+        throw err;
+      });
     actions.setShowLoadingSpinner();
 
     return provider;
@@ -441,6 +446,7 @@ const storeThunks = {
     await providersApi.editProvider(payload)
       .catch((err) => {
         actions.setProvidersError(err.response.data.message);
+        actions.setShowLoadingSpinner();
         throw err;
       });
     actions.setShowLoadingSpinner();

--- a/store/store.js
+++ b/store/store.js
@@ -27,6 +27,8 @@ const storeState = {
   },
   menusError: '',
   providersError: '',
+  chargeRecipes: false,
+  chargeMenus: false,
   chargeProviders: false,
   showLoadingSpinner: false,
   ingredientsInventory: {},
@@ -99,6 +101,12 @@ const storeActions = {
   }),
   setLoadRecipes: action((state, payload) => {
     state.recipes.load = payload;
+  }),
+  setChargeRecipes: action((state) => {
+    state.chargeRecipes = !state.chargeRecipes;
+  }),
+  setChargeMenus: action((state) => {
+    state.chargeMenus = !state.chargeMenus;
   }),
   setChargeProviders: action((state) => {
     state.chargeProviders = !state.chargeProviders;

--- a/store/store.js
+++ b/store/store.js
@@ -231,15 +231,16 @@ const storeThunks = {
 
     return ingredients;
   }),
-  getRecipes: thunk(async (actions, payload) => {
-    actions.setShowLoadingSpinner();
+  getRecipes: thunk(async (actions, payload, { getStoreState }) => {
+    const state = getStoreState();
+    if (!state.chargeRecipes) actions.setShowLoadingSpinner();
     const recipes = await recipesApi.getRecipes(payload)
       .then((res) => res.data.data)
       .catch((err) => {
         actions.setGetRecipesError(err.response.data.message);
         throw err;
       });
-    actions.setShowLoadingSpinner();
+    if (!state.chargeRecipes) actions.setShowLoadingSpinner();
 
     return recipes;
   }),
@@ -342,15 +343,16 @@ const storeThunks = {
 
     return resp;
   }),
-  getMenus: thunk(async (actions, payload) => {
-    actions.setShowLoadingSpinner();
+  getMenus: thunk(async (actions, payload, { getStoreState }) => {
+    const state = getStoreState();
+    if (!state.chargeMenus) actions.setShowLoadingSpinner();
     const menus = await menusApi.getMenus(payload)
       .then((res) => res.data.data)
       .catch((err) => {
         actions.setMenusError(err.response.data.message);
         throw err;
       });
-    actions.setShowLoadingSpinner();
+    if (!state.chargeMenus) actions.setShowLoadingSpinner();
 
     return menus;
   }),
@@ -415,15 +417,16 @@ const storeThunks = {
 
     return shoppingList.data;
   }),
-  getProviders: thunk(async (actions, payload) => {
-    actions.setShowLoadingSpinner();
+  getProviders: thunk(async (actions, payload, { getStoreState }) => {
+    const state = getStoreState();
+    if (!state.chargeProviders) actions.setShowLoadingSpinner();
     const providers = await providersApi.getProviders(payload)
       .then((res) => res.data.data)
       .catch((err) => {
         actions.setProvidersError(err.response.data.message);
         throw err;
       });
-    actions.setShowLoadingSpinner();
+    if (!state.chargeProviders) actions.setShowLoadingSpinner();
 
     return providers;
   }),

--- a/store/store.js
+++ b/store/store.js
@@ -27,9 +27,9 @@ const storeState = {
   },
   menusError: '',
   providersError: '',
-  chargeRecipes: false,
-  chargeMenus: false,
-  chargeProviders: false,
+  hasToGetRecipes: false,
+  hasToGetMenus: false,
+  hasToGetProviders: false,
   showLoadingSpinner: false,
   ingredientsInventory: {},
 };
@@ -102,14 +102,14 @@ const storeActions = {
   setLoadRecipes: action((state, payload) => {
     state.recipes.load = payload;
   }),
-  setChargeRecipes: action((state) => {
-    state.chargeRecipes = !state.chargeRecipes;
+  setHasToGetRecipes: action((state) => {
+    state.hasToGetRecipes = !state.hasToGetRecipes;
   }),
-  setChargeMenus: action((state) => {
-    state.chargeMenus = !state.chargeMenus;
+  setHasToGetMenus: action((state) => {
+    state.hasToGetMenus = !state.hasToGetMenus;
   }),
-  setChargeProviders: action((state) => {
-    state.chargeProviders = !state.chargeProviders;
+  setHasToGetProviders: action((state) => {
+    state.hasToGetProviders = !state.hasToGetProviders;
   }),
   setShowLoadingSpinner: action((state) => {
     state.showLoadingSpinner = !state.showLoadingSpinner;
@@ -233,14 +233,14 @@ const storeThunks = {
   }),
   getRecipes: thunk(async (actions, payload, { getStoreState }) => {
     const state = getStoreState();
-    if (!state.chargeRecipes) actions.setShowLoadingSpinner();
+    if (!state.hasToGetRecipes) actions.setShowLoadingSpinner();
     const recipes = await recipesApi.getRecipes(payload)
       .then((res) => res.data.data)
       .catch((err) => {
         actions.setGetRecipesError(err.response.data.message);
         throw err;
       });
-    if (!state.chargeRecipes) actions.setShowLoadingSpinner();
+    if (!state.hasToGetRecipes) actions.setShowLoadingSpinner();
 
     return recipes;
   }),
@@ -345,14 +345,14 @@ const storeThunks = {
   }),
   getMenus: thunk(async (actions, payload, { getStoreState }) => {
     const state = getStoreState();
-    if (!state.chargeMenus) actions.setShowLoadingSpinner();
+    if (!state.hasToGetMenus) actions.setShowLoadingSpinner();
     const menus = await menusApi.getMenus(payload)
       .then((res) => res.data.data)
       .catch((err) => {
         actions.setMenusError(err.response.data.message);
         throw err;
       });
-    if (!state.chargeMenus) actions.setShowLoadingSpinner();
+    if (!state.hasToGetMenus) actions.setShowLoadingSpinner();
 
     return menus;
   }),
@@ -419,14 +419,14 @@ const storeThunks = {
   }),
   getProviders: thunk(async (actions, payload, { getStoreState }) => {
     const state = getStoreState();
-    if (!state.chargeProviders) actions.setShowLoadingSpinner();
+    if (!state.hasToGetProviders) actions.setShowLoadingSpinner();
     const providers = await providersApi.getProviders(payload)
       .then((res) => res.data.data)
       .catch((err) => {
         actions.setProvidersError(err.response.data.message);
         throw err;
       });
-    if (!state.chargeProviders) actions.setShowLoadingSpinner();
+    if (!state.hasToGetProviders) actions.setShowLoadingSpinner();
 
     return providers;
   }),

--- a/styles/Menus/showStyles.js
+++ b/styles/Menus/showStyles.js
@@ -156,10 +156,20 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginVertical: 3,
   },
+  bold: {
+    fontWeight: '600',
+  },
   modalTitle: {
     width: '100%',
     fontSize: 16,
     fontWeight: 'bold',
+    color: colors.kitchengramBlack,
+    textAlign: 'center',
+    marginBottom: 2,
+  },
+  modalSubtitle: {
+    width: '100%',
+    fontSize: 15,
     color: colors.kitchengramBlack,
     textAlign: 'center',
     marginBottom: 10,

--- a/styles/Providers/formStyles.js
+++ b/styles/Providers/formStyles.js
@@ -117,6 +117,66 @@ const styles = StyleSheet.create({
   confirmText: {
     color: colors.kitchengramWhite,
   },
+
+  centeredView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 25,
+  },
+
+  modalView: {
+    minHeight: '20%',
+    maxHeight: '50%',
+    minWidth: '90%',
+    margin: 20,
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 20,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  modalTitle: {
+    width: '100%',
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: colors.kitchengramBlack,
+    textAlign: 'center',
+    marginBottom: 10,
+  },
+
+  modalButtonContainer: {
+    width: '100%',
+    height: 30,
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+
+  confirmButton: {
+    width: '48%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.kitchengramGreen500,
+    borderRadius: 5,
+  },
+
+  confirmButtonText: {
+    color: colors.kitchengramWhite,
+  },
 });
 
 export default styles;


### PR DESCRIPTION
# Que se hizo
Varios arreglos,

1. En recetas ya no se permiten crear pasos vacíos
2. En un menú no se puede copiar/exportar si este es vacío (sin recetas)
3. No se puede crear/editar un proveedor cuyo nombre ya existe (levanta un warning avisando)
4. Manejo de decimales en modal de reducir inventario desde un menú

Además antes cuando se cambiaba el valor de un ingrediente que pertenecía a una receta, el valor de está última no se actualizaba. Lo mismo con los menús (cuando se actualizaba el valor de una receta).

Por lo que ahora cada vez que se actualiza la lista de ingredientes se vuelve a hacer un llamado a la api `getRecipes` para obtener estas actualizadas.
De la misma forma cuando una receta se actualiza se hace un llamado a la api `getMenus` para que estos se actualicen.

# QA

- Revisar los puntos 1 - 4, ya que antes de estos fines la aplicación se caía.
- Verificar que al cambiar el valor de un ingrediente, se actualiza el valor de las recetas que tienen a ese ingrediente y a su vez el valor de los menús que tienen esas recetas.