### PR TITLE
add equivalent measures and fix style

### DIFF
--- a/components/IngredientMeasureRow.js
+++ b/components/IngredientMeasureRow.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Text, TextInput, View } from 'react-native';
+import { TextInput, View } from 'react-native';
 import RNPickerSelect from 'react-native-picker-select';
 import Icon from 'react-native-vector-icons/Ionicons';
 
@@ -7,7 +7,7 @@ import styles from '../styles/Ingredients/formStyles';
 import pickers from '../styles/customPickerStyles';
 import colors from '../styles/appColors';
 
-function IngredientMeasureRow({ measure, handleMeasureChange, isDefault, hasLabels }) {
+function IngredientMeasureRow({ measure, handleMeasureChange, isDefault }) {
   const [measuresOptions, setMeasuresOptions] = useState(['Unidad', 'Kilo', 'Gramo', 'Litro', 'Mililitro',
     'Oz', 'Taza', 'Cucharada', 'Cucharadita', 'Otra']);
   const [measureName, setMeasureName] = useState(measure.name);
@@ -33,11 +33,6 @@ function IngredientMeasureRow({ measure, handleMeasureChange, isDefault, hasLabe
     <>
       <View style={styles.rowContainer}>
         <View style={styles.inputUnitContainer}>
-          { hasLabels ?
-            <Text style={styles.inputLabel}>
-              Cantidad
-            </Text> : null
-          }
           <TextInput
             style={styles.input}
             placeholder="Cantidad de ingrediente..."
@@ -48,11 +43,6 @@ function IngredientMeasureRow({ measure, handleMeasureChange, isDefault, hasLabe
           />
         </View>
         <View style={styles.inputUnitContainer}>
-          {hasLabels ?
-            <Text style={styles.inputLabel}>
-              Unidad
-            </Text> : null
-          }
           <View style={styles.dropDown}>
             <RNPickerSelect
               style={pickers.customPickerStyles}

--- a/components/IngredientMeasureRow.js
+++ b/components/IngredientMeasureRow.js
@@ -78,6 +78,7 @@ function IngredientMeasureRow({ measure, handleMeasureChange, isDefault }) {
               returnKeyType='done'
               value={otherMeasureName}
               onChangeText={setOtherMeasureName}
+              onEndEditing={() => handleNewMeasure()}
             />
           </View>
           <View>

--- a/screens/Ingredients/FormIngredientScreen.js
+++ b/screens/Ingredients/FormIngredientScreen.js
@@ -78,6 +78,10 @@ function FormIngredient({ navigation, route }) {
   function handleMeasureChange(id, newMeasureAttributes) {
     const toChangeMeasureIndex = measures.findIndex((thisMeasure) => thisMeasure.id === id);
     if (toChangeMeasureIndex === -1) return;
+    if (newMeasureAttributes.name &&
+      measures.findIndex(measure => !measure.isRemoved && measure.name === newMeasureAttributes.name) !== -1) {
+      return;
+    }
     const toChangeMeasure = { ...measures[toChangeMeasureIndex], ...newMeasureAttributes };
     const auxMeasures = [
       ...measures.slice(0, toChangeMeasureIndex),
@@ -145,8 +149,8 @@ function FormIngredient({ navigation, route }) {
       { error: measures[0].quantity <= 0, message: 'Debes ingresar una cantidad por defecto' },
       { error: !measures[0].name, message: 'Debes ingresar una medida por defecto' },
       ...measures.slice(1).map(thisMeasure => ({
-        error: !thisMeasure.isRemoved && !thisMeasure.name,
-        message: 'Debes ingresar una medida a la unidad equivalente',
+        error: !thisMeasure.isRemoved && (!thisMeasure.name || thisMeasure.name === 'Otra'),
+        message: 'Debes ingresar una medida válida a la unidad equivalente',
       })),
       ...measures.slice(1).map(thisMeasure => ({
         error: !thisMeasure.isRemoved && !thisMeasure.quantity,

--- a/screens/Ingredients/FormIngredientScreen.js
+++ b/screens/Ingredients/FormIngredientScreen.js
@@ -85,7 +85,7 @@ function FormIngredient({ navigation, route }) {
       ...measures.slice(toChangeMeasureIndex + 1),
     ];
 
-    const equivalentMeasures = ['Kilo', 'Gramo', 'Oz', 'Litro', 'Mililitro'];
+    const equivalentMeasures = ['Kilo', 'Gramo', 'Oz', 'Litro', 'Mililitro', 'Taza', 'Cucharada', 'Cucharadita'];
     if (!toChangeMeasure.isRemoved && toChangeMeasure.name && toChangeMeasure.quantity &&
       equivalentMeasures.includes(toChangeMeasure.name)) {
       const conversions = {
@@ -94,6 +94,9 @@ function FormIngredient({ navigation, route }) {
         Oz: [{ name: 'Kilo', quantity: 0.02835 }, { name: 'Gramo', quantity: 0.00002835 }],
         Litro: [{ name: 'Mililitro', quantity: 1000 }],
         Mililitro: [{ name: 'Litro', quantity: 0.001 }],
+        Taza: [{ name: 'Cucharada', quantity: 16 }, { name: 'Cucharadita', quantity: 48 }],
+        Cucharada: [{ name: 'Cucharadita', quantity: 3 }, { name: 'Taza', quantity: 0.0625 }],
+        Cucharadita: [{ name: 'Taza', quantity: 0.0283 }, { name: 'Cucharada', quantity: 0.33 }],
       };
       conversions[toChangeMeasure.name].forEach(conv => {
         const newId = Math.max(...auxMeasures.map(measure => Number(measure.id)), 0) + 1;

--- a/screens/Ingredients/SearchIngredientScreen.js
+++ b/screens/Ingredients/SearchIngredientScreen.js
@@ -95,7 +95,7 @@ function SearchIngredient({ navigation, route }) {
                   setName(product.name);
                   setPrice(product.price);
                   setProviderName(searchResponse[actualProvider].provider.name);
-                  setMeasure({ name: product.measure, quantity: 1 });
+                  setMeasure({ name: product.measure, quantity: product.quantity });
                   navigation.navigate('Nuevo Ingrediente', {
                     isFromSearch: true,
                   });

--- a/styles/Ingredients/formStyles.js
+++ b/styles/Ingredients/formStyles.js
@@ -37,6 +37,15 @@ const styles = StyleSheet.create({
     backgroundColor: colors.kitchengramWhite,
   },
 
+  qtyAndUnitLabel: {
+    width: '40%',
+    marginRight: '5%',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    marginVertical: -10,
+  },
+
   inputNewMeasureContainer: {
     width: '86%',
     height: 60,


### PR DESCRIPTION
**Qué se hizo**

* Se agregan automáticamente las unidades equivalentes de Kilo-Gramo-Oz y Litro-mL
* se centró la cruz de las unidades alternativas
* no se puede agregar medidas si hay una que le faltan datos
* se incluye la cantidad del ingrediente de cornershop (frontend)

**QA**
* Probar todos los casos bordes en las unidades en un ingrediente nuevo o editándolo

![WhatsApp Image 2021-07-17 at 21 36 19](https://user-images.githubusercontent.com/42159846/126053148-14473fc2-1233-44ec-82dc-dc2b8b068467.jpeg)
