### PR TITLE
fix(reduce-inventory-menu): fixed NaN number in reduce inventory modal

### DIFF
--- a/screens/Menus/MenuScreen.js
+++ b/screens/Menus/MenuScreen.js
@@ -98,10 +98,11 @@ function Menu(props) {
         const id = ingredient.attributes.ingredient.id.toString();
         let newInventory = 0;
         if (Object.keys(newIngredientsInventoryCopy).includes(id)) {
-          newInventory = newIngredientsInventoryCopy[id] - ingredient.attributes.ingredientQuantity;
+          newInventory = parseFloat(
+            newIngredientsInventoryCopy[id].quantity) - ingredient.attributes.ingredientQuantity;
         } else {
           totalIngredients += 1;
-          newInventory = ingredientsInventory[id] - ingredient.attributes.ingredientQuantity;
+          newInventory = parseFloat(ingredientsInventory[id]) - ingredient.attributes.ingredientQuantity;
         }
         newIngredientsInventoryCopy[id] = {
           // eslint-disable-next-line no-magic-numbers
@@ -202,8 +203,9 @@ function Menu(props) {
                         {`${newIngredientsInventory[key].name}:`}
                       </Text>
                       <Text style={styles.modalText}>
-                        {`Tienes ${ingredientsInventory[key]} - ` +
-                        `Quedarán ${newIngredientsInventory[key].quantity} ${newIngredientsInventory[key].measure}`}
+                        {`Tienes ${ingredientsInventory[key].toFixed(1)} - ` +
+                        `Quedarán ${
+                          newIngredientsInventory[key].quantity.toFixed(1)} ${newIngredientsInventory[key].measure}`}
                       </Text>
                     </View>
                   ))}
@@ -225,8 +227,8 @@ function Menu(props) {
                       {`${key}:`}
                     </Text>
                     <Text style={styles.modalText}>
-                      {`Tienes ${ingredientsInventory[alertIngredients[key].id]} - ` +
-                      `Faltan ${alertIngredients[key].quantity} ${alertIngredients[key].measure}`}
+                      {`Tienes ${ingredientsInventory[alertIngredients[key].id].toFixed(1)} - ` +
+                      `Faltan ${alertIngredients[key].quantity.toFixed(1)} ${alertIngredients[key].measure}`}
                     </Text>
                   </View>
                 ))}


### PR DESCRIPTION
* Se arregla que aparezca `NaN` algunas veces al reducir inventario en Menú
* Se truncan los números decimales a un dígito significativo