### PR TITLE
feat(store): create persist session logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.13.0",
     "@react-native-community/masked-view": "0.1.10",
     "@react-native-picker/picker": "1.9.11",
     "@react-navigation/bottom-tabs": "^5.11.10",

--- a/screens/Main.js
+++ b/screens/Main.js
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useStoreState } from 'easy-peasy';
 import { NavigationContainer } from '@react-navigation/native';
-
+import apiUtils from '../api/api';
 import LogIn from './Users/LogInScreen';
 import SignUp from './Users/SignUpScreen';
 import ForgotPassword from './Users/forgotPasswordScreen';
@@ -13,7 +13,15 @@ function Main() {
   const loggedOutView = useStoreState((state) => state.loggedOutView);
   const showLoadingSpinner = useStoreState((state) => state.showLoadingSpinner);
 
-  if (currentUser) {
+  useEffect(() => {
+    if (currentUser.email) {
+      apiUtils.api.defaults.headers = { 'Accept': 'application/json',
+        'Content-Type': 'application/json', 'X-User-Email': currentUser.email,
+        'X-User-Token': currentUser.authenticationToken };
+    }
+  }, [currentUser]);
+
+  if (currentUser.email) {
     return (
       <>
         <NavigationContainer>

--- a/screens/Main.js
+++ b/screens/Main.js
@@ -1,5 +1,6 @@
+/* eslint-disable max-statements */
 import React, { useEffect } from 'react';
-import { useStoreState } from 'easy-peasy';
+import { useStoreState, useStoreRehydrated } from 'easy-peasy';
 import { NavigationContainer } from '@react-navigation/native';
 import apiUtils from '../api/api';
 import LogIn from './Users/LogInScreen';
@@ -9,6 +10,7 @@ import HomeTabs from '../navigators/bottomNavigation';
 import Spinner from '../components/Spinner';
 
 function Main() {
+  const rehydrated = useStoreRehydrated();
   const currentUser = useStoreState((state) => state.currentUser);
   const loggedOutView = useStoreState((state) => state.loggedOutView);
   const showLoadingSpinner = useStoreState((state) => state.showLoadingSpinner);
@@ -24,9 +26,11 @@ function Main() {
   if (currentUser.email) {
     return (
       <>
+        {rehydrated &&
         <NavigationContainer>
           <HomeTabs />
         </NavigationContainer>
+        }
         {showLoadingSpinner && <Spinner /> }
       </>
     );
@@ -35,14 +39,16 @@ function Main() {
   if (loggedOutView === 'login') {
     return (
       <>
-        <LogIn />
+        {rehydrated &&
+        <LogIn />}
         {showLoadingSpinner && <Spinner /> }
       </>
     );
   } else if (loggedOutView === 'forgot_password') {
     return (
       <>
-        <ForgotPassword />
+        {rehydrated &&
+        <ForgotPassword />}
         {showLoadingSpinner && <Spinner /> }
       </>
     );
@@ -50,7 +56,8 @@ function Main() {
 
   return (
     <>
-      <SignUp />
+      {rehydrated &&
+      <SignUp />}
       {showLoadingSpinner && <Spinner /> }
     </>
   );

--- a/store/store.js
+++ b/store/store.js
@@ -7,9 +7,25 @@ import recipesApi from '../api/recipes';
 import menusApi from '../api/menus';
 import providersApi from '../api/providers';
 
+const reactNativeStorage = {
+  async getItem(key) {
+    const rawValue = await AsyncStorage.getItem(key);
+
+    return JSON.parse(rawValue);
+  },
+  setItem(key, data) {
+    const parsedValue = JSON.stringify(data);
+
+    return AsyncStorage.setItem(key, parsedValue);
+  },
+  removeItem(key) {
+    return AsyncStorage.removeItem(key);
+  },
+};
+
 const storeState = {
   currentUser: persist({ email: '', authenticationToken: '' },
-    { storage: AsyncStorage }),
+    { storage: reactNativeStorage }),
   loginError: '',
   signUpError: '',
   changePasswordError: '',
@@ -69,6 +85,9 @@ const storeActions = {
     if (payload.status === apiUtils.statusCodes.ok || payload.status === apiUtils.statusCodes.created) {
       const user = payload.data.data.attributes;
       state.currentUser = user;
+      apiUtils.api.defaults.headers = { 'Accept': 'application/json',
+        'Content-Type': 'application/json', 'X-User-Email': user.email,
+        'X-User-Token': user.authenticationToken };
     }
   }),
   setIngredientsError: action((state, payload) => {
@@ -526,6 +545,8 @@ const storeThunks = {
   }),
 };
 
+// eslint-disable-next-line no-undef
+window.requestIdleCallback = null;
 const generateStore = createStore({
   ...storeState,
   ...getters,

--- a/store/store.js
+++ b/store/store.js
@@ -1,4 +1,5 @@
-import { createStore, action, thunk } from 'easy-peasy';
+import { createStore, action, thunk, persist } from 'easy-peasy';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import apiUtils from '../api/api';
 import sessionsApi from '../api/sessions';
 import ingredientsApi from '../api/ingredients';
@@ -7,7 +8,8 @@ import menusApi from '../api/menus';
 import providersApi from '../api/providers';
 
 const storeState = {
-  currentUser: null,
+  currentUser: persist({ email: '', authenticationToken: '' },
+    { storage: AsyncStorage }),
   loginError: '',
   signUpError: '',
   changePasswordError: '',
@@ -67,9 +69,6 @@ const storeActions = {
     if (payload.status === apiUtils.statusCodes.ok || payload.status === apiUtils.statusCodes.created) {
       const user = payload.data.data.attributes;
       state.currentUser = user;
-      apiUtils.api.defaults.headers = { 'Accept': 'application/json',
-        'Content-Type': 'application/json', 'X-User-Email': user.email,
-        'X-User-Token': user.authenticationToken };
     }
   }),
   setIngredientsError: action((state, payload) => {
@@ -106,7 +105,7 @@ const storeActions = {
     state.providersError = payload;
   }),
   setLogOut: action((state) => {
-    state.currentUser = null;
+    state.currentUser = { email: '', authenticationToken: '' };
     apiUtils.api.defaults.headers = { 'Accept': 'application/json',
       'Content-Type': 'application/json' };
   }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,6 +1665,13 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
+"@react-native-async-storage/async-storage@^1.13.0":
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.15.5.tgz#0d221a5ef1cd7a6494a42fcaad43136d68379afb"
+  integrity sha512-4AYehLH39B9a8UXCMf3ieOK+G61wGMP72ikx6/XSMA0DUnvx0PgaeaT2Wyt06kTrDTy8edewKnbrbeqwaM50TQ==
+  dependencies:
+    deep-assign "^3.0.0"
+
 "@react-native-community/cli-debugger-ui@^4.13.1":
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.13.1.tgz#07de6d4dab80ec49231de1f1fbf658b4ad39b32c"


### PR DESCRIPTION
## Que se hizo
- se implemento que se mantuviera la sesión actual de forma que no haya que iniciar sesión cada vez que se ingresa a la app.
- para esto se utilizó la función `persist` de easy-peasy para mantener guardado al `currentUser`

## QA
- Ingresar con un usuario cualquiera e iniciar sesión, luego reiniciar la app y ver que envíe a la vista de index de ingredientes sin solicitar las credenciales.
- probar que no haya problemas al cerrar sesión y reiniciar la app