### PR TITLE
fix(searchIngredient): improve picker style

### DIFF
--- a/screens/Ingredients/SearchIngredientScreen.js
+++ b/screens/Ingredients/SearchIngredientScreen.js
@@ -79,11 +79,12 @@ function SearchIngredient({ navigation, route }) {
                   label: element.provider.name,
                   value: i,
                 }))}
-              />
-              <Icon name='chevron-down'
-                size={25}
-                color={colors.kitchengramGreen500}
-                style={styles.arrowIcon}
+                Icon={() =>
+                  <Icon name='chevron-down'
+                    size={25}
+                    color={colors.kitchengramGreen500}
+                    style={styles.arrowIcon}
+                  />}
               />
             </View>
             {searchResponse[actualProvider].products.map((product, i) => (

--- a/styles/customPickerStyles.js
+++ b/styles/customPickerStyles.js
@@ -45,23 +45,25 @@ const pickers = {
   },
   providerPicker: {
     inputIOS: {
+      textAlign: 'left',
       color: colors.kitchengramGreen500,
-      textAlign: 'center',
-      paddingTop: 13,
-      paddingHorizontal: 10,
-      paddingBottom: 12,
+      paddingTop: 10,
+      marginHorizontal: 10,
       fontSize: 16,
 
     },
     inputAndroid: {
-      textAlign: 'center',
+      textAlign: 'left',
       color: colors.kitchengramGreen500,
-      paddingTop: 20,
-      paddingBottom: 13,
+      paddingTop: 40,
       marginHorizontal: 10,
       fontSize: 16,
     },
     placeholderColor: colors.kitchengramGreen500,
+    iconContainer: {
+      top: Platform.OS === 'ios' ? '23%' : '20%',
+      right: '10%',
+    },
   },
 };
 


### PR DESCRIPTION
## que se hizo
se arregló el estilo de la flecha del dropdown del scrapper, eliminando la flecha duplicada que venía por defecto

## QA
Buscar un ingrediente del scraper y al cargarse el dropdown ver que tanto el texto como la flecha se encuentren centradas en altura en dentro del borde y que no se vea una segunda flecha aparte de la verde